### PR TITLE
v2.0.2

### DIFF
--- a/.github/workflows/laravel-report-php-7-4.yml
+++ b/.github/workflows/laravel-report-php-7-4.yml
@@ -18,16 +18,7 @@ jobs:
             php-version: '7.4'
       - name: Validate composer.json and composer.lock
         run: composer validate
-      - name: Cache Composer packages
-        id: composer-cache
-        uses: actions/cache@v2
-        with:
-          path: vendor
-          key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-php-
       - name: Install dependencies
-        if: steps.composer-cache.outputs.cache-hit != 'true'
         run: composer install --prefer-dist --no-progress --no-suggest
       - name: Execute tests via PHPUnit
         run: vendor/bin/phpunit

--- a/.github/workflows/laravel-report-php.yml
+++ b/.github/workflows/laravel-report-php.yml
@@ -18,16 +18,7 @@ jobs:
             php-version: '8.0'
       - name: Validate composer.json and composer.lock
         run: composer validate
-      - name: Cache Composer packages
-        id: composer-cache
-        uses: actions/cache@v2
-        with:
-          path: vendor
-          key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-php-
       - name: Install dependencies
-        if: steps.composer-cache.outputs.cache-hit != 'true'
         run: composer install --prefer-dist --no-progress --no-suggest
       - name: Execute tests via PHPUnit
         run: vendor/bin/phpunit

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,19 @@
+## v2.0.2
+
++ Add support for queued report rendering
+  + GET /api/report/queue              report.queue.index
+  + POST /api/report/queue/{report}    report.queue.render
+  + GET /api/report/queue/job/{job}    report.queue.job
+  + GET /api/report/queue/result/{job} report.queue.result
+  + GET /api/report/queue/export/{job} report.queue.export
++ Persist report data in to filesystem as a CSV
++ Export report from filesystem
+
+## v2.0.1
+
++ Remove support for Laravel version 5
++ Require illuminate/queue
+
 ## v2.0.0
 
 + bump support for php from ^7.1 to 7.4 or ^8.0

--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,3 @@
-
 {
   "name": "mblsolutions/report",
   "description": "MBL Solutions Laravel Reports",
@@ -14,11 +13,15 @@
   "require": {
     "php": "^7.4|^8.0",
     "ext-json": "*",
-    "illuminate/console": "~5.6.0|~5.7.0|~5.8.0|^6.0|^7.0|^8.0",
-    "illuminate/events": "~5.6.0|~5.7.0|~5.8.0|^6.0|^7.0|^8.0",
-    "illuminate/database": "~5.6.0|~5.7.0|~5.8.0|^6.0|^7.0|^8.0",
-    "illuminate/support": "~5.6.0|~5.7.0|~5.8.0|^6.0|^7.0|^8.0",
-    "illuminate/http": "~5.6.0|~5.7.0|~5.8.0|^6.0|^7.0|^8.0"
+    "illuminate/cache": "^6.0|^7.0|^8.0",
+    "illuminate/console": "^6.0|^7.0|^8.0",
+    "illuminate/database": "^6.0|^7.0|^8.0",
+    "illuminate/events": "^6.0|^7.0|^8.0",
+    "illuminate/filesystem": "^6.0|^7.0|^8.0",
+    "illuminate/queue": "^6.0|^7.0|^8.0",
+    "illuminate/support": "^6.0|^7.0|^8.0",
+    "illuminate/http": "^6.0|^7.0|^8.0",
+    "maatwebsite/excel": "^3.1"
   },
   "require-dev": {
     "mockery/mockery": "~1.0",

--- a/config/report.php
+++ b/config/report.php
@@ -45,7 +45,7 @@ return [
     |
     | Reports can be hidden and/or protected using custom middleware to
     | prevent users viewing reports. Middleware can also be used to add
-    | protection queries to reports to prevent users viewing data they
+    | protection queries to report's preventing users viewing data they
     | should not e.g. table.user_id = {current_user_id}
     |
     | @interface \MBLSolutions\Report\Interfaces\ReportMiddleware
@@ -73,5 +73,29 @@ return [
         \MBLSolutions\Report\Driver\Export\PrintExport::class,
         \MBLSolutions\Report\Driver\Export\JsonExport::class,
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Report Filesystem Disk
+    |--------------------------------------------------------------------------
+    |
+    | Specify the filesystem driver you would like to use for reports to be
+    | stored.
+    |
+    */
+
+    'filesystem' => env('REPORT_FILESYSTEM_DRIVER', 'local'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Report Filesystem Path
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure the path on the filesystem disk where reports should
+    | be stored.
+    |
+    */
+
+    'filesystem_path' => env('REPORT_FILESYSTEM_PATH', 'reports/'),
 
 ];

--- a/database/migrations/2016_06_01_000006_create_report_jobs_table.php
+++ b/database/migrations/2016_06_01_000006_create_report_jobs_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use MBLSolutions\Report\Support\Enums\JobStatus;
+
+class CreateReportJobsTable extends Migration
+{
+
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('report_jobs', static function (Blueprint $table) {
+            $table->uuid('uuid');
+            $table->unsignedInteger('report_id')->index();
+            $table->string('status', 20)->default(JobStatus::SCHEDULED);
+            $table->string('authenticatable_id')->nullable()->index();
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('report_jobs');
+    }
+
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         backupGlobals="false"
          backupStaticAttributes="false"
          beStrictAboutTestsThatDoNotTestAnything="false"
-         bootstrap="vendor/autoload.php"
-         colors="true"
+         bootstrap="vendor/autoload.php" colors="true"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
@@ -13,21 +13,21 @@
          stopOnError="false"
          stopOnFailure="false"
          verbose="true"
->
-    <testsuites>
-        <testsuite name="MBL Solutions Report Test Suite">
-            <directory suffix="Test.php">./tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
-    <php>
-        <server name="APP_KEY" value="AckfSECXIvnK5r28GVIWUAxmbBSjTsmF"/>
-        <server name="APP_ENV" value="testing"/>
-        <server name="DB_CONNECTION" value="sqlite"/>
-        <server name="DB_DATABASE" value=":memory:"/>
-    </php>
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="MBL Solutions Report Test Suite">
+      <directory suffix="Test.php">./tests</directory>
+    </testsuite>
+  </testsuites>
+  <php>
+    <server name="APP_KEY" value="AckfSECXIvnK5r28GVIWUAxmbBSjTsmF"/>
+    <server name="APP_ENV" value="testing"/>
+    <server name="DB_CONNECTION" value="sqlite"/>
+    <server name="DB_DATABASE" value=":memory:"/>
+  </php>
 </phpunit>

--- a/readme.md
+++ b/readme.md
@@ -144,7 +144,7 @@ Please Note: We recommend that large record sets are not used as select types, d
 
 The following endpoints are available to you once the routes have been added:
 
-#### View Routes
+#### View Routes (synchronous)
 
 | Method    | URI                           | Name                      |
 | ---       | ---                           | ---                       |
@@ -156,6 +156,17 @@ The following endpoints are available to you once the routes have been added:
 | GET       | /api/report/middleware        | report.middleware.list    |
 | GET       | /api/report/data/type         | report.data.type.list     |
 | GET       | /api/report/model             | report.model.list         |
+
+
+### Queued View Routes (asynchronous)
+
+| Method    | URI                               | Name                      |
+| ---       | ---                               | ---                       |
+| GET       | /api/report/queue                 | report.queue.index        |
+| POST      | /api/report/queue/{report}        | report.queue.render       |
+| GET       | /api/report/queue/job/{job}       | report.queue.job          |
+| GET       | /api/report/queue/result/{job}    | report.queue.result       |
+| GET       | /api/report/queue/export/{job}    | report.queue.export       |
 
 #### Export Routes
 
@@ -175,3 +186,15 @@ The following endpoints are available to you once the routes have been added:
 | DELETE    | /api/report/manage/{report}   | report.manage.destroy     |
 | DELETE    | /api/report/manage/settings   | report.manage.settings    |
 
+### Report Events
+
+Events are fired at critical points during report creation/completion
+
+| Event               | Description                                | Data                           | Namespace                                          |
+| ---                 | ---                                        | ---                            | ---                                                |
+| ReportCreated       | A new report was created.                  | Report $report                 |  MBLSolutions\Report\Events\ReportCreated          |
+| ReportUpdated       | A report was updated.                      | Report $report                 |  MBLSolutions\Report\Events\ReportUpdated          |
+| ReportDestroyed     | A report was deleted.                      | Report $report                 |  MBLSolutions\Report\Events\ReportDestroyed        |
+| ReportRendered      | A report was rendered.                     | Report $report                 |  MBLSolutions\Report\Events\ReportRendered         |
+| ReportExported      | A report was exported.                     | Report $report                 |  MBLSolutions\Report\Events\ReportExported         |
+| ReportRenderStarted | A queued report job to render was started. | Report $report, ReportJob $job |  MBLSolutions\Report\Events\ReportRenderStarted    |

--- a/src/Events/ReportEvent.php
+++ b/src/Events/ReportEvent.php
@@ -7,7 +7,7 @@ use MBLSolutions\Report\Models\Report;
 abstract class ReportEvent
 {
     /** @var Report $report */
-    public $report;
+    public Report $report;
 
     /**
      * Create a new Report Event instance

--- a/src/Events/ReportRenderStarted.php
+++ b/src/Events/ReportRenderStarted.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace MBLSolutions\Report\Events;
+
+use MBLSolutions\Report\Models\Report;
+use MBLSolutions\Report\Models\ReportJob;
+
+class ReportRenderStarted extends ReportEvent
+{
+
+    public ReportJob $job;
+
+    /**
+     * Create a new Report Event instance
+     *
+     * @param Report $report
+     * @param ReportJob $job
+     */
+    public function __construct(Report $report, ReportJob $job)
+    {
+        $this->job = $job;
+
+        parent::__construct($report);
+    }
+
+}

--- a/src/Export/Report/ReportExport.php
+++ b/src/Export/Report/ReportExport.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace MBLSolutions\Report\Export\Report;
+
+use Illuminate\Support\Collection;
+use Maatwebsite\Excel\Concerns\FromCollection;
+use MBLSolutions\Report\Services\BuildReportService;
+
+class ReportExport implements FromCollection
+{
+
+    protected BuildReportService $service;
+
+    public function __construct(BuildReportService $service)
+    {
+        $this->service = $service;
+    }
+
+    public function collection(): Collection
+    {
+        return $this->service->render()->get('data');
+    }
+
+}

--- a/src/Http/Controllers/QueuedReportController.php
+++ b/src/Http/Controllers/QueuedReportController.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace MBLSolutions\Report\Http\Controllers;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Storage;
+use MBLSolutions\Report\Jobs\RenderReport;
+use MBLSolutions\Report\Models\Report;
+use MBLSolutions\Report\Models\ReportJob;
+use MBLSolutions\Report\Repositories\ReportRepository;
+use MBLSolutions\Report\Support\Report\RenderJobUuidGenerator;
+use RuntimeException;
+
+class QueuedReportController
+{
+    /** @var ReportRepository $repository */
+    protected ReportRepository $repository;
+
+    /**
+     * Report Controller
+     *
+     * @param ReportRepository $repository
+     */
+    public function __construct(ReportRepository $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    /**
+     * View Report Job Index
+     *
+     * @return JsonResponse
+     */
+    public function index(): JsonResponse
+    {
+        return new JsonResponse(ReportJob::orderByDesc('updated_at')->paginate(), 200);
+    }
+
+    /**
+     * Render a Report
+     *
+     * @param Report $report
+     * @param Request $request
+     * @return JsonResponse
+     */
+    public function render(Report $report, Request $request): JsonResponse
+    {
+        $data = app(RenderJobUuidGenerator::class)->__invoke();
+
+        Bus::dispatch(new RenderReport($data->get('uuid'), $report, $request->toArray()));
+
+        return new JsonResponse($data, 202);
+    }
+
+    /**
+     * View Report Job Status
+     *
+     * @param ReportJob $job
+     * @return JsonResponse
+     */
+    public function job(ReportJob $job): JsonResponse
+    {
+        return new JsonResponse($job, 200);
+    }
+
+    public function export(ReportJob $job): JsonResponse
+    {
+        try {
+            // TODO handle this better
+            $url = Storage::disk(config('report.filesystem'))->temporaryUrl(
+                config('report.filesystem_path', 'reports/') . $job->getKey() . '.csv',
+                Carbon::now()->addDay(),
+                [
+                    'ResponseContentType' => 'application/octet-stream',
+                    'ResponseContentDisposition' => 'attachment; filename=' . $job->getKey() . '.csv',
+                ]
+            );
+        } catch (RuntimeException $exception) {
+            $url = Storage::disk(config('report.filesystem'))->url(config('report.filesystem_path', 'reports/') . $job->getKey() . '.csv',);
+        }
+
+        return new JsonResponse([
+            'url' => $url
+        ], 200);
+    }
+
+}

--- a/src/Jobs/RenderReport.php
+++ b/src/Jobs/RenderReport.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace MBLSolutions\Report\Jobs;
+
+use Exception;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Http\Request;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Maatwebsite\Excel\Facades\Excel;
+use MBLSolutions\Report\Events\ReportRenderStarted;
+use MBLSolutions\Report\Export\Report\ReportExport;
+use MBLSolutions\Report\Models\Report;
+use MBLSolutions\Report\Models\ReportJob;
+use MBLSolutions\Report\Services\BuildReportService;
+use MBLSolutions\Report\Support\Enums\JobStatus;
+
+class RenderReport implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public Report $report;
+
+    public ReportJob $reportJob;
+
+    public array $request;
+
+    public function __construct(string $uuid, Report $report, array $request = [])
+    {
+        $this->report = $report;
+        $this->reportJob = $this->initiateRenderReportJob($uuid);
+        $this->request = $request;
+    }
+
+    public function handle(): void
+    {
+        try {
+            $this->reportJob->update(['status' => JobStatus::RUNNING]);
+
+            $service = new BuildReportService($this->report, $this->request, false);
+
+            Excel::store(
+                new ReportExport($service),
+                config('report.filesystem_path', 'reports/') . $this->reportJob->getKey() . '.csv',
+                config('report.filesystem')
+            );
+
+            $this->reportJob->update(['status' => JobStatus::COMPLETE]);
+
+        } catch (Exception $exception) {
+            $this->reportJob->update(['status' => JobStatus::FAILED]);
+
+            throw $exception;
+        }
+    }
+
+    protected function initiateRenderReportJob(string $uuid): ReportJob
+    {
+        $model = new ReportJob([
+            'uuid' => $uuid,
+            'report_id' => $this->report->getKey(),
+            'status' => JobStatus::SCHEDULED,
+        ]);
+
+        $model->save();
+
+        event(new ReportRenderStarted($this->report, $job = $model->refresh()));
+
+        return $job;
+    }
+
+}

--- a/src/Models/ReportJob.php
+++ b/src/Models/ReportJob.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace MBLSolutions\Report\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class ReportJob extends Model
+{
+    use SoftDeletes;
+
+    protected $primaryKey = 'uuid';
+
+    public $incrementing = false;
+
+    protected $keyType = 'string';
+
+    /** {@inheritDoc} */
+    protected $guarded = [];
+
+}

--- a/src/Report.php
+++ b/src/Report.php
@@ -73,6 +73,14 @@ class Report
             Route::get('report/data/type', 'DataTypeController@index')->name('data.type.list');
             Route::get('report/model', 'ModelController@index')->name('model.list');
 
+            // Asynchronous
+            Route::get('report/queue', 'QueuedReportController@index')->name('queue.index');
+            Route::post('report/queue/{report}', 'QueuedReportController@render')->name('queue.render');
+            Route::get('report/queue/job/{job}', 'QueuedReportController@job')->name('queue.job');
+            // TODO Route::get('report/queue/result/{job}', 'QueuedReportController@result')->name('queue.result');
+            Route::get('report/queue/export/{job}', 'QueuedReportController@export')->name('queue.export');
+
+            // Synchronous
             Route::get('report', 'ReportController@index')->name('index');
             Route::get('report/{report}', 'ReportController@show')->name('show');
             Route::post('report/{report}', 'ReportController@render')->name('render');

--- a/src/Services/BuildReportService.php
+++ b/src/Services/BuildReportService.php
@@ -17,7 +17,7 @@ use MBLSolutions\Report\Support\Maps\ReportResultMap;
 class BuildReportService
 {
     /** @var bool $paginate */
-    public $paginate = true;
+    public $paginate;
 
     /** @var Report $report */
     protected $report;
@@ -36,9 +36,11 @@ class BuildReportService
      *
      * @param Report $report
      * @param array $parameters
+     * @param bool $paginate
      */
-    public function __construct(Report $report, array $parameters = [])
+    public function __construct(Report $report, array $parameters = [], bool $paginate = true)
     {
+        $this->paginate = $paginate;
         $this->report = $report;
         $this->parameters = collect($parameters);
 

--- a/src/Support/Enums/JobStatus.php
+++ b/src/Support/Enums/JobStatus.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace MBLSolutions\Report\Support\Enums;
+
+use MBLSolutions\Report\Support\EnumModel;
+
+class JobStatus extends EnumModel
+{
+    public const SCHEDULED = 'scheduled';
+
+    public const RUNNING = 'running';
+
+    public const COMPLETE = 'complete';
+
+    public const FAILED = 'failed';
+
+}

--- a/src/Support/Report/RenderJobUuidGenerator.php
+++ b/src/Support/Report/RenderJobUuidGenerator.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace MBLSolutions\Report\Support\Report;
+
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+
+class RenderJobUuidGenerator
+{
+
+    public function __invoke(): Collection
+    {
+        return new Collection([
+            'uuid' => $uuid = Str::uuid(),
+            'href' => route('report.queue.job', ['job' => $uuid]),
+        ]);
+
+    }
+    
+}

--- a/tests/Feature/ConnectionControllerTest.php
+++ b/tests/Feature/ConnectionControllerTest.php
@@ -10,7 +10,7 @@ class ConnectionControllerTest extends LaravelTestCase
     /** @test **/
     public function can_get_available_connections(): void
     {
-        $response = $this->getJson('report/connection');
+        $response = $this->getJson(route('report.connection.list'));
 
         $response->assertStatus(200);
     }

--- a/tests/Feature/DataTypeControllerTest.php
+++ b/tests/Feature/DataTypeControllerTest.php
@@ -10,7 +10,7 @@ class DataTypeControllerTest extends LaravelTestCase
     /** @test **/
     public function can_get_available_data_types(): void
     {
-        $response = $this->getJson('report/data/type');
+        $response = $this->getJson(route('report.data.type.list'));
 
         $response->assertStatus(200);
     }

--- a/tests/Feature/ManageReportControllerTest.php
+++ b/tests/Feature/ManageReportControllerTest.php
@@ -13,7 +13,7 @@ class ManageReportControllerTest extends LaravelTestCase
     {
         factory(Report::class)->create(['name' => 'Test Report']);
 
-        $response = $this->getJson('/report/manage');
+        $response = $this->getJson(route('report.manage.index'));
 
         $response->assertStatus(200)
             ->assertJson([
@@ -28,9 +28,9 @@ class ManageReportControllerTest extends LaravelTestCase
     /** @test **/
     public function can_show_manage_report(): void
     {
-        factory(Report::class)->create(['name' => 'Test Report']);
+        $report = factory(Report::class)->create(['name' => 'Test Report']);
 
-        $response = $this->getJson('/report/manage/1');
+        $response = $this->getJson(route('report.manage.show', ['report' => $report->getKey()]));
 
         $response->assertStatus(200)
             ->assertJson([
@@ -43,7 +43,7 @@ class ManageReportControllerTest extends LaravelTestCase
     /** @test **/
     public function can_show_manage_report_for_new_report(): void
     {
-        $response = $this->getJson('/report/manage/null');
+        $response = $this->getJson(route('report.manage.show', ['report' => 'null']));
 
         $response->assertStatus(200)
             ->assertJson([
@@ -56,7 +56,7 @@ class ManageReportControllerTest extends LaravelTestCase
     /** @test **/
     public function can_store_a_new_report(): void
     {
-        $response = $this->postJson('/report/manage', [
+        $response = $this->postJson(route('report.manage.store'), [
             'name' => 'Test Report',
             'description' => 'A test report.',
             'connection' => 'sqlite',
@@ -73,7 +73,7 @@ class ManageReportControllerTest extends LaravelTestCase
     /** @test **/
     public function create_missing_or_invalid_data_returns_422(): void
     {
-        $response = $this->postJson('/report/manage');
+        $response = $this->postJson(route('report.manage.store'));
 
         $response->assertStatus(422);
     }
@@ -81,12 +81,12 @@ class ManageReportControllerTest extends LaravelTestCase
     /** @test **/
     public function can_update_a_report(): void
     {
-        factory(Report::class)->create([
+        $report = factory(Report::class)->create([
             'name' => 'Test Report',
             'description' => 'A test report.',
         ]);
 
-        $response = $this->patchJson('/report/manage/1', [
+        $response = $this->patchJson(route('report.manage.update', ['report' => $report->getKey()]), [
             'name' => 'Updated Test Report',
             'description' => 'This report was updated.',
             'connection' => 'sqlite',
@@ -103,12 +103,12 @@ class ManageReportControllerTest extends LaravelTestCase
     /** @test **/
     public function update_missing_or_invalid_data_returns_422(): void
     {
-        factory(Report::class)->create([
+        $report = factory(Report::class)->create([
             'name' => 'Test Report',
             'description' => 'A test report.',
         ]);
 
-        $response = $this->patchJson('/report/manage/1');
+        $response = $this->patchJson(route('report.manage.destroy', ['report' => $report->getKey()]));
 
         $response->assertStatus(422);
     }
@@ -116,9 +116,9 @@ class ManageReportControllerTest extends LaravelTestCase
     /** @test **/
     public function can_delete_a_report(): void
     {
-        factory(Report::class)->create();
+        $report = factory(Report::class)->create();
 
-        $response = $this->deleteJson('/report/manage/1');
+        $response = $this->deleteJson(route('report.manage.destroy', ['report' => $report->getKey()]));
 
         $response->assertStatus(200);
     }
@@ -126,9 +126,9 @@ class ManageReportControllerTest extends LaravelTestCase
     /** @test **/
     public function can_test_if_a_report_is_successful(): void
     {
-        factory(Report::class)->create();
+        $report = factory(Report::class)->create();
 
-        $response = $this->postJson('/report/manage/1/test');
+        $response = $this->postJson(route('report.manage.test', ['report' => $report->getKey()]));
 
         $response->assertStatus(200)
                  ->assertJson([
@@ -139,11 +139,11 @@ class ManageReportControllerTest extends LaravelTestCase
     /** @test **/
     public function can_test_if_a_report_has_failed(): void
     {
-        factory(Report::class)->create([
+        $report = factory(Report::class)->create([
             'table' => 'invalid_table'
         ]);
 
-        $response = $this->postJson('/report/manage/1/test');
+        $response = $this->postJson(route('report.manage.test', ['report' => $report->getKey()]));
 
         $response->assertStatus(200)
                  ->assertJson([

--- a/tests/Feature/ManageSettingsControllerTest.php
+++ b/tests/Feature/ManageSettingsControllerTest.php
@@ -10,7 +10,7 @@ class ManageSettingsControllerTest extends LaravelTestCase
     /** @test **/
     public function can_get_manage_report_settings(): void
     {
-        $response = $this->getJson('/report/manage/settings');
+        $response = $this->getJson(route('report.manage.settings'));
 
         $response->assertStatus(200);
     }

--- a/tests/Feature/ModelControllerTest.php
+++ b/tests/Feature/ModelControllerTest.php
@@ -10,7 +10,7 @@ class ModelControllerTest extends LaravelTestCase
     /** @test **/
     public function can_get_available_models(): void
     {
-        $response = $this->getJson('report/model');
+        $response = $this->getJson(route('report.model.list'));
 
         $response->assertStatus(200);
     }

--- a/tests/Feature/QueuedReportControllerTest.php
+++ b/tests/Feature/QueuedReportControllerTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace MBLSolutions\Report\Tests\Feature;
+
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Storage;
+use Maatwebsite\Excel\Facades\Excel;
+use MBLSolutions\Report\Jobs\RenderReport;
+use MBLSolutions\Report\Models\Report;
+use MBLSolutions\Report\Models\ReportJob;
+use MBLSolutions\Report\Support\Report\RenderJobUuidGenerator;
+use MBLSolutions\Report\Tests\LaravelTestCase;
+
+class QueuedReportControllerTest extends LaravelTestCase
+{
+
+    /** {@inheritdoc} **/
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Excel::fake();
+        Bus::fake();
+    }
+
+    /** @test **/
+    public function can_view_report_queue_index(): void
+    {
+        $this->getJson(route('report.queue.index'))->assertStatus(200);
+    }
+    
+    /** @test **/
+    public function can_render_a_queued_report(): void
+    {
+        $data = collect([
+            'uuid' => '931c1666-a70f-422b-aefe-925ab8b59aeb',
+            'href' => route('report.queue.job', ['job' => '931c1666-a70f-422b-aefe-925ab8b59aeb']),
+        ]);
+
+        $this->app->instance(RenderJobUuidGenerator::class, function () use ($data) {
+            return $data;
+        });
+
+        $this->postJson(route('report.queue.render', [
+            'report' => factory(Report::class)->create()->getKey()
+        ]))
+        ->assertStatus(202)
+        ->assertJson($data->toArray());
+    }
+    
+    /** @test **/
+    public function rendering_a_queued_report_dispatches_render_report_job(): void
+    {
+        $this->postJson(route('report.queue.render', [
+            'report' => $report = factory(Report::class)->create()
+        ]));
+
+        Bus::assertDispatched(RenderReport::class, function ($job) use ($report) {
+            return $job->report->getKey() === $report->getKey();
+        });
+    }
+
+    /** @test **/
+    public function can_view_job_status(): void
+    {
+        factory(ReportJob::class)->create([
+            'uuid' => '931c1666-a70f-422b-aefe-925ab8b59aeb'
+        ]);
+
+        $this->getJson(route('report.queue.job', [
+            'job' => '931c1666-a70f-422b-aefe-925ab8b59aeb'
+        ]))->assertStatus(200);
+    }
+
+    /** @test **/
+    public function can_generate_export_link(): void
+    {
+        $this->withoutExceptionHandling();
+
+        Storage::fake();
+
+        factory(ReportJob::class)->create([
+            'uuid' => '931c1666-a70f-422b-aefe-925ab8b59aeb'
+        ]);
+
+        $this->getJson(route('report.queue.export', ['job' => '931c1666-a70f-422b-aefe-925ab8b59aeb']))->assertStatus(200);
+    }
+
+}

--- a/tests/Feature/ReportControllerTest.php
+++ b/tests/Feature/ReportControllerTest.php
@@ -18,7 +18,7 @@ class ReportControllerTest extends LaravelTestCase
     {
         factory(Report::class)->create(['name' => 'Test Report']);
 
-        $response = $this->getJson('/report');
+        $response = $this->getJson(route('report.index'));
 
         $response->assertStatus(200)
                  ->assertJson([
@@ -33,9 +33,9 @@ class ReportControllerTest extends LaravelTestCase
     /** @test **/
     public function can_show_report(): void
     {
-        factory(Report::class)->create(['name' => 'Test Report']);
+        $report = factory(Report::class)->create(['name' => 'Test Report']);
 
-        $response = $this->getJson('/report/1');
+        $response = $this->getJson(route('report.show', ['report' => $report->getKey()]));
 
         $response->assertStatus(200)
                  ->assertJson([
@@ -48,9 +48,9 @@ class ReportControllerTest extends LaravelTestCase
     /** @test **/
     public function can_render_a_report(): void
     {
-        factory(Report::class)->create();
+        $report = factory(Report::class)->create();
 
-        $response = $this->postJson('/report/1');
+        $response = $this->postJson(route('report.render', ['report' => $report->getKey()]));
 
         $response->assertStatus(200);
     }
@@ -58,9 +58,9 @@ class ReportControllerTest extends LaravelTestCase
     /** @test **/
     public function can_generate_report_export_uri(): void
     {
-        factory(Report::class)->create();
+        $report = factory(Report::class)->create();
 
-        $response = $this->actingAs(new User)->postJson('/report/1/export');
+        $response = $this->actingAs(new User)->postJson(route('report.export', ['report' => $report->getKey()]));
 
         $response->assertStatus(200);
     }

--- a/tests/Feature/ReportMiddlewareControllerTest.php
+++ b/tests/Feature/ReportMiddlewareControllerTest.php
@@ -10,7 +10,7 @@ class ReportMiddlewareControllerTest extends LaravelTestCase
     /** @test **/
     public function can_get_available_middleware(): void
     {
-        $response = $this->getJson('report/middleware');
+        $response = $this->getJson(route('report.middleware.list'));
 
         $response->assertStatus(200);
     }

--- a/tests/LaravelTestCase.php
+++ b/tests/LaravelTestCase.php
@@ -4,6 +4,7 @@ namespace MBLSolutions\Report\Tests;
 
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Maatwebsite\Excel\ExcelServiceProvider;
 use MBLSolutions\Report\Report;
 use MBLSolutions\Report\ReportServiceProvider;
 use MBLSolutions\Report\Tests\Fakes\ExportDriver\FakeExportDriver;
@@ -48,6 +49,9 @@ class LaravelTestCase extends OTBTestCase
         $app['config']->set(
             'report.export_drivers', array_merge($config['export_drivers'], [FakeExportDriver::class])
         );
+        $app['config']->set('report.filesystem', $config['filesystem']);
+        $app['config']->set('report.filesystem_path', $config['filesystem_path']);
+
     }
 
     /**
@@ -56,7 +60,10 @@ class LaravelTestCase extends OTBTestCase
      */
     protected function getPackageProviders($app): array
     {
-        return [ReportServiceProvider::class];
+        return [
+            ReportServiceProvider::class,
+            ExcelServiceProvider::class
+        ];
     }
 
     /**

--- a/tests/Unit/Jobs/RenderReportJobTest.php
+++ b/tests/Unit/Jobs/RenderReportJobTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace MBLSolutions\Report\Tests\Unit\Jobs;
+
+use Illuminate\Support\Facades\Event;
+use MBLSolutions\Report\Events\ReportRenderStarted;
+use MBLSolutions\Report\Jobs\RenderReport;
+use MBLSolutions\Report\Models\Report;
+use MBLSolutions\Report\Support\Enums\JobStatus;
+use MBLSolutions\Report\Tests\LaravelTestCase;
+
+class RenderReportJobTest extends LaravelTestCase
+{
+    protected $report;
+
+    /** {@inheritdoc} **/
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Event::fake();
+
+        $this->report = factory(Report::class)->create();
+    }
+
+    /** @test **/
+    public function can_create_a_report_render_job(): void
+    {
+        new RenderReport('aa5615b7-8489-4831-ad00-f50ae770b619', $this->report);
+
+        $this->assertDatabaseHas('report_jobs', [
+            'uuid' => 'aa5615b7-8489-4831-ad00-f50ae770b619',
+            'report_id' => $this->report->getKey(),
+            'status' => JobStatus::SCHEDULED
+        ]);
+    }
+
+    /** @test **/
+    public function creating_a_job_fires_report_job_started_event(): void
+    {
+        new RenderReport('aa5615b7-8489-4831-ad00-f50ae770b619', $this->report);
+
+        Event::assertDispatched(ReportRenderStarted::class, function ($event) {
+            return $event->job->getKey() === 'aa5615b7-8489-4831-ad00-f50ae770b619';
+        });
+    }
+
+    /** @test **/
+    public function dispatching_render_report_completes_job_status(): void
+    {
+        dispatch(new RenderReport('aa5615b7-8489-4831-ad00-f50ae770b619', $this->report));
+
+        $this->assertDatabaseHas('report_jobs', [
+            'uuid' => 'aa5615b7-8489-4831-ad00-f50ae770b619',
+            'report_id' => $this->report->getKey(),
+            'status' => JobStatus::COMPLETE
+        ]);
+    }
+
+}

--- a/tests/database/factories/ModelFactory.php
+++ b/tests/database/factories/ModelFactory.php
@@ -4,12 +4,15 @@
 
 use Faker\Generator as Faker;
 use Illuminate\Database\Eloquent\Factory;
+use Illuminate\Support\Str;
 use MBLSolutions\Report\DataType\CastTitleCaseString;
 use MBLSolutions\Report\Models\Report;
 use MBLSolutions\Report\Models\ReportField;
+use MBLSolutions\Report\Models\ReportJob;
 use MBLSolutions\Report\Models\ReportJoin;
 use MBLSolutions\Report\Models\ReportMiddleware;
 use MBLSolutions\Report\Models\ReportSelect;
+use MBLSolutions\Report\Support\Enums\JobStatus;
 use MBLSolutions\Report\Tests\Fakes\Middleware\FakeMiddleware;
 
 $factory->define(Report::class, static function (Faker $faker) {
@@ -66,5 +69,16 @@ $factory->define(ReportField::class, static function (Faker $faker) {
         'alias' => 'users_created_date',
         'model_select_value' => null,
         'model_select_name' => null
+    ];
+});
+
+$factory->define(ReportJob::class, static function (Faker $faker) {
+    return [
+        'uuid' => Str::uuid(),
+        'report_id' => function () {
+            return factory(Report::class)->create();
+        },
+        'status' => JobStatus::SCHEDULED,
+        'authenticatable_id' => null,
     ];
 });


### PR DESCRIPTION
## v2.0.2

+ Add support for queued report rendering
  + GET /api/report/queue              report.queue.index
  + POST /api/report/queue/{report}    report.queue.render
  + GET /api/report/queue/job/{job}    report.queue.job
  + GET /api/report/queue/result/{job} report.queue.result
  + GET /api/report/queue/export/{job} report.queue.export
+ Persist report data in to filesystem as a CSV
+ Export report from filesystem

## v2.0.1

+ Remove support for Laravel version 5
+ Require illuminate/queue
