### PR TITLE
v2.4

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,7 +6,8 @@
   + GET /report/schedule
   + POST /report/schedule
   + DELETE /report/schedule/{schedule}
-+ Add new Command `\MBLSolutions\Report\Console\Commands\DispatchScheduledReportsCommand::class` 
++ Add new Command `\MBLSolutions\Report\Console\Commands\DispatchScheduledReportsCommand::class`
++ Add a report render preview, limited to 1000 results (can be overridden use the `REPORT_PREVIEW_LIMIT` env)
 
 ## v2.3.0
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,12 @@
+## v2.4.0
+
++ Add scheduled report migration
++ Add scheduled report model
++ Add scheduled report routes
+  + GET /report/schedule
+  + POST /report/schedule
+  + DELETE /report/schedule/{schedule}
+
 ## v2.3.0
 
 + Fire event for each job chunk completed

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
   + GET /report/schedule
   + POST /report/schedule
   + DELETE /report/schedule/{schedule}
++ Add new Command `\MBLSolutions\Report\Console\Commands\DispatchScheduledReportsCommand::class` 
 
 ## v2.3.0
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     "illuminate/queue": "^6.0|^7.0|^8.0",
     "illuminate/support": "^6.0|^7.0|^8.0",
     "illuminate/http": "^6.0|^7.0|^8.0",
-    "maatwebsite/excel": "^3.1"
+    "maatwebsite/excel": "^3.1",
+    "lerouse/laravel-repository": "^1.2"
   },
   "require-dev": {
     "mockery/mockery": "~1.0",

--- a/config/report.php
+++ b/config/report.php
@@ -129,6 +129,18 @@ return [
         \MBLSolutions\Report\Driver\QueuedExport\XlsxQueuedExport::class,
         \MBLSolutions\Report\Driver\QueuedExport\OdsQueuedExport::class,
         \MBLSolutions\Report\Driver\QueuedExport\TsvQueuedExport::class,
-    ]
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Report Preview Limit
+    |--------------------------------------------------------------------------
+    |
+    | The maximum number of records that should be displayed as part of the
+    | report preview.
+    |
+    */
+
+    'preview_limit' => env('REPORT_PREVIEW_LIMIT', 1000),
 
 ];

--- a/database/migrations/2016_06_01_000006_create_report_jobs_table.php
+++ b/database/migrations/2016_06_01_000006_create_report_jobs_table.php
@@ -20,6 +20,7 @@ class CreateReportJobsTable extends Migration
             $table->unsignedInteger('report_id')->index();
             $table->string('status', 20)->default(JobStatus::SCHEDULED);
             $table->string('authenticatable_id')->nullable()->index();
+            $table->string('schedule_id')->nullable()->index();
             $table->unsignedInteger('processed')->nullable();
             $table->unsignedInteger('total')->nullable();
             $table->text('parameters')->nullable();

--- a/database/migrations/2016_06_01_000007_create_scheduled_reports_table.php
+++ b/database/migrations/2016_06_01_000007_create_scheduled_reports_table.php
@@ -17,11 +17,13 @@ class CreateScheduledReportsTable extends Migration
     {
         Schema::create('scheduled_reports', static function (Blueprint $table) {
             $table->uuid('uuid');
-            $table->string('schedule')->index()->default(ReportSchedule::MONTHLY);
             $table->unsignedInteger('report_id')->index();
-            $table->string('authenticatable_id')->nullable()->index();
             $table->text('parameters')->nullable();
+            $table->string('frequency')->index()->default(ReportSchedule::MONTHLY);
+            $table->dateTime('limit')->nullable();
+            $table->text('recipients')->nullable();
             $table->dateTime('last_run')->nullable();
+            $table->string('authenticatable_id')->nullable()->index();
             $table->timestamps();
             $table->softDeletes();
         });

--- a/database/migrations/2016_06_01_000007_create_scheduled_reports_table.php
+++ b/database/migrations/2016_06_01_000007_create_scheduled_reports_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use MBLSolutions\Report\Support\Enums\ReportSchedule;
+
+class CreateScheduledReportsTable extends Migration
+{
+
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('scheduled_reports', static function (Blueprint $table) {
+            $table->uuid('uuid');
+            $table->string('schedule')->index()->default(ReportSchedule::MONTHLY);
+            $table->unsignedInteger('report_id')->index();
+            $table->string('authenticatable_id')->nullable()->index();
+            $table->text('parameters')->nullable();
+            $table->dateTime('last_run')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('scheduled_reports');
+    }
+
+}

--- a/readme.md
+++ b/readme.md
@@ -140,6 +140,15 @@ Please Note: We recommend that large record sets are not used as select types, d
 ]
 ```
 
+### Scheduled Reporting
+
+To enable scheduled reporting add the following line into the `schedule` method of the `\App\Console\Kernel` file of your
+laravel application.
+
+```php
+$schedule->command(\MBLSolutions\Report\Console\Commands\DispatchScheduledReportsCommand::class)->hourly();
+```
+
 ### Report JSON API
 
 The following endpoints are available to you once the routes have been added:
@@ -168,6 +177,16 @@ The following endpoints are available to you once the routes have been added:
 | GET       | /api/report/queue/result/{job}    | report.queue.result       |
 | GET       | /api/report/queue/export/{job}    | report.queue.export       |
 
+
+### Scheduled Report Routes
+
+| Method    | URI                               | Name                          |
+| ---       | ---                               | ---                           |
+| GET       | /report/schedule/frequency        | report.schedule.frequencies   |
+| GET       | /report/schedule                  | report.schedule.index         |
+| POST      | /report/schedule                  | report.schedule.create        |
+| DELETE    | /report/schedule/{schedule}       | report.schedule.destroy       |
+
 #### Export Routes
 
 | Method    | URI                           | Name                      |
@@ -190,13 +209,14 @@ The following endpoints are available to you once the routes have been added:
 
 Events are fired at critical points during report creation/completion
 
-| Event                 | Description                                | Data                           | Namespace                                          |
-| ---                   | ---                                        | ---                            | ---                                                |
-| ReportCreated         | A new report was created.                  | Report $report                 |  MBLSolutions\Report\Events\ReportCreated          |
-| ReportUpdated         | A report was updated.                      | Report $report                 |  MBLSolutions\Report\Events\ReportUpdated          |
-| ReportDestroyed       | A report was deleted.                      | Report $report                 |  MBLSolutions\Report\Events\ReportDestroyed        |
-| ReportRendered        | A report was rendered.                     | Report $report                 |  MBLSolutions\Report\Events\ReportRendered         |
-| ReportExported        | A report was exported.                     | Report $report                 |  MBLSolutions\Report\Events\ReportExported         |
-| ReportRenderStarted   | A queued report job to render was started. | Report $report, ReportJob $job |  MBLSolutions\Report\Events\ReportRenderStarted    |
-| ReportChunkComplete   | A queued report job chunk was completed.   | Report $report, ReportJob $job |  MBLSolutions\Report\Events\ReportChunkComplete    |
-| ReportRenderComplete  | A queued report job render was completed.  | Report $report, ReportJob $job |  MBLSolutions\Report\Events\ReportRenderComplete   |
+| Event                      | Description                                | Data                           | Namespace                                          |
+| ---                        | ---                                        | ---                            | ---                                                |
+| ReportCreated              | A new report was created.                  | Report $report                 |  MBLSolutions\Report\Events\ReportCreated          |
+| ReportUpdated              | A report was updated.                      | Report $report                 |  MBLSolutions\Report\Events\ReportUpdated          |
+| ReportDestroyed            | A report was deleted.                      | Report $report                 |  MBLSolutions\Report\Events\ReportDestroyed        |
+| ReportRendered             | A report was rendered.                     | Report $report                 |  MBLSolutions\Report\Events\ReportRendered         |
+| ReportExported             | A report was exported.                     | Report $report                 |  MBLSolutions\Report\Events\ReportExported         |
+| ReportRenderStarted        | A queued report job to render was started. | Report $report, ReportJob $job |  MBLSolutions\Report\Events\ReportRenderStarted    |
+| ReportChunkComplete        | A queued report job chunk was completed.   | Report $report, ReportJob $job |  MBLSolutions\Report\Events\ReportChunkComplete    |
+| ReportRenderComplete       | A queued report job render was completed.  | Report $report, ReportJob $job |  MBLSolutions\Report\Events\ReportRenderComplete   |
+| ScheduledReportDispatched  | A scheduled report was run.                | ScheduledReport $schedule      |  MBLSolutions\Report\Events\ReportRenderComplete   |

--- a/src/Console/Commands/DispatchScheduledReportsCommand.php
+++ b/src/Console/Commands/DispatchScheduledReportsCommand.php
@@ -34,7 +34,8 @@ class DispatchScheduledReportsCommand extends Command
 
         $this->info('Running Report Schedules');
 
-        $repository->getScheduledReportsToRun($this->date)->each(function (ScheduledReport $schedule) {
+        // TODO put back
+        $repository->all($this->date)->each(function (ScheduledReport $schedule) {
             $this->info(
                 sprintf('Running Schedule for Report %s', $schedule->getKey())
             );

--- a/src/Console/Commands/DispatchScheduledReportsCommand.php
+++ b/src/Console/Commands/DispatchScheduledReportsCommand.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace MBLSolutions\Report\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Str;
+use MBLSolutions\Report\Events\ScheduledReportDispatched;
+use MBLSolutions\Report\Jobs\RenderReport;
+use MBLSolutions\Report\Models\Report;
+use MBLSolutions\Report\Models\ScheduledReport;
+use MBLSolutions\Report\Repositories\ScheduledReportRepository;
+
+class DispatchScheduledReportsCommand extends Command
+{
+    protected \Carbon\Carbon $date;
+
+    protected $signature = 'report:schedule';
+
+    protected $description = 'Dispatch scheduled reports';
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->date = Carbon::now();
+    }
+
+    public function handle(): int
+    {
+        $repository = new ScheduledReportRepository();
+
+        $this->info('Running Report Schedules');
+
+        $repository->getScheduledReportsToRun($this->date)->each(function (ScheduledReport $schedule) {
+            $this->info(
+                sprintf('Running Schedule for Report %s', $schedule->getKey())
+            );
+
+            $uuid = Str::uuid();
+            $report = Report::find($schedule->getAttribute('report_id'));
+
+            Bus::dispatch(
+                new RenderReport(
+                    $uuid, $report, $schedule->getAttribute('parameters'), $schedule->getAttribute('authenticatable_id'), $schedule->getKey()
+                )
+            );
+
+            Event::dispatch(new ScheduledReportDispatched($schedule));
+        });
+
+        return 0;
+    }
+
+}

--- a/src/Console/Commands/DispatchScheduledReportsCommand.php
+++ b/src/Console/Commands/DispatchScheduledReportsCommand.php
@@ -34,8 +34,7 @@ class DispatchScheduledReportsCommand extends Command
 
         $this->info('Running Report Schedules');
 
-        // TODO put back
-        $repository->all($this->date)->each(function (ScheduledReport $schedule) {
+        $repository->getScheduledReportsToRun($this->date)->each(function (ScheduledReport $schedule) {
             $this->info(
                 sprintf('Running Schedule for Report %s', $schedule->getKey())
             );

--- a/src/Events/ScheduledReportDispatched.php
+++ b/src/Events/ScheduledReportDispatched.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace MBLSolutions\Report\Events;
+
+use MBLSolutions\Report\Models\ScheduledReport;
+
+class ScheduledReportDispatched
+{
+
+    public ScheduledReport $schedule;
+
+    public function __construct(ScheduledReport $schedule)
+    {
+        $this->schedule = $schedule;
+    }
+
+}

--- a/src/Http/Controllers/ReportController.php
+++ b/src/Http/Controllers/ReportController.php
@@ -103,4 +103,18 @@ class ReportController
         return (new ExportReportService($report, $request))->handle();
     }
 
+    /**
+     * View the report preview
+     *
+     * @param Report $report
+     * @param Request $request
+     * @return mixed
+     */
+    public function preview(Report $report, Request $request)
+    {
+        $service = new BuildReportService($report, $request->toArray(), false);
+
+        return $service->renderPreview(config('report.preview_limit'));
+    }
+
 }

--- a/src/Http/Controllers/ScheduledReportController.php
+++ b/src/Http/Controllers/ScheduledReportController.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace MBLSolutions\Report\Http\Controllers;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+use MBLSolutions\Report\Http\Resources\ScheduledReportCollection;
+use MBLSolutions\Report\Http\Resources\ScheduledReportResource;
+use MBLSolutions\Report\Models\ScheduledReport;
+use MBLSolutions\Report\Repositories\ScheduledReportRepository;
+
+class ScheduledReportController
+{
+    /** @var ScheduledReportRepository $repository */
+    protected ScheduledReportRepository $repository;
+
+    /**
+     * Report Controller
+     *
+     * @param ScheduledReportRepository $repository
+     */
+    public function __construct(ScheduledReportRepository $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    public function index(Request $request): ScheduledReportCollection
+    {
+        return new ScheduledReportCollection(
+            $this->repository->paginate($request->get('limit', config('app.pagination_limit')))
+        );
+    }
+
+    public function create(Request $request): ScheduledReportResource
+    {
+        $schedule = new ScheduledReport(array_merge([
+            'uuid' => Str::uuid()
+        ], $request->toArray()));
+
+
+        $schedule->save();
+
+        return new ScheduledReportResource($schedule);
+    }
+
+    /**
+     * Delete a Scheduled Report
+     *
+     * @param ScheduledReport $schedule
+     * @return JsonResponse
+     * @throws \Exception
+     */
+    public function destroy(ScheduledReport $schedule): JsonResponse
+    {
+        $schedule->delete();
+
+        return new JsonResponse(null, 204);
+    }
+
+}

--- a/src/Http/Controllers/ScheduledReportController.php
+++ b/src/Http/Controllers/ScheduledReportController.php
@@ -34,6 +34,12 @@ class ScheduledReportController
         );
     }
 
+    /**
+     * Create a Scheduled Report
+     *
+     * @param Request $request
+     * @return ScheduledReportResource
+     */
     public function create(Request $request): ScheduledReportResource
     {
         $request->validate([
@@ -53,6 +59,13 @@ class ScheduledReportController
         return new ScheduledReportResource($schedule);
     }
 
+    /**
+     * Delete a Scheduled Report
+     *
+     * @param ScheduledReport $schedule
+     * @return JsonResponse
+     * @throws \Exception
+     */
     public function destroy(ScheduledReport $schedule): JsonResponse
     {
         $schedule->delete();
@@ -60,6 +73,11 @@ class ScheduledReportController
         return new JsonResponse(null, 204);
     }
 
+    /**
+     * Get the report Run frequencies
+     *
+     * @return Collection
+     */
     public function frequencies(): Collection
     {
         return ReportSchedule::options();

--- a/src/Http/Controllers/ScheduledReportController.php
+++ b/src/Http/Controllers/ScheduledReportController.php
@@ -4,11 +4,13 @@ namespace MBLSolutions\Report\Http\Controllers;
 
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use MBLSolutions\Report\Http\Resources\ScheduledReportCollection;
 use MBLSolutions\Report\Http\Resources\ScheduledReportResource;
 use MBLSolutions\Report\Models\ScheduledReport;
 use MBLSolutions\Report\Repositories\ScheduledReportRepository;
+use MBLSolutions\Report\Support\Enums\ReportSchedule;
 
 class ScheduledReportController
 {
@@ -34,6 +36,13 @@ class ScheduledReportController
 
     public function create(Request $request): ScheduledReportResource
     {
+        $request->validate([
+            'report_id' => 'required|exists:reports,id',
+            'parameters' => 'required',
+            'frequency' => 'required',
+            'limit' => 'nullable|integer',
+        ]);
+
         $schedule = new ScheduledReport(array_merge([
             'uuid' => Str::uuid()
         ], $request->toArray()));
@@ -44,18 +53,16 @@ class ScheduledReportController
         return new ScheduledReportResource($schedule);
     }
 
-    /**
-     * Delete a Scheduled Report
-     *
-     * @param ScheduledReport $schedule
-     * @return JsonResponse
-     * @throws \Exception
-     */
     public function destroy(ScheduledReport $schedule): JsonResponse
     {
         $schedule->delete();
 
         return new JsonResponse(null, 204);
+    }
+
+    public function frequencies(): Collection
+    {
+        return ReportSchedule::options();
     }
 
 }

--- a/src/Http/Resources/ScheduledReportCollection.php
+++ b/src/Http/Resources/ScheduledReportCollection.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace MBLSolutions\Report\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\ResourceCollection;
+
+class ScheduledReportCollection extends ResourceCollection
+{
+    /**
+     * Transform the resource collection into an array.
+     *
+     * @param  Request  $request
+     * @return array
+     */
+    public function toArray($request): array
+    {
+        return $this->collection->transform(static function ($model) {
+            return new ScheduledReportResource($model);
+        })->toArray();
+    }
+}

--- a/src/Http/Resources/ScheduledReportResource.php
+++ b/src/Http/Resources/ScheduledReportResource.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace MBLSolutions\Report\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class ScheduledReportResource extends JsonResource
+{
+
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  Request  $request
+     * @return array
+     * @codeCoverageIgnore
+     */
+    public function toArray($request): array
+    {
+        return [
+            'uuid' => $this->getKey(),
+            'schedule' => $this->getAttribute('schedule'),
+            'report_id' => $this->getAttribute('report_id'),
+            'authenticatable_id' => $this->getAttribute('authenticatable_id'),
+            'parameters' => $this->getAttribute('parameters'),
+            'last_run' => $this->getAttribute('last_run'),
+            'created_at' => $this->getAttribute('created_at'),
+            'updated_at' => $this->getAttribute('updated_at'),
+        ];
+    }
+
+}

--- a/src/Jobs/RenderReport.php
+++ b/src/Jobs/RenderReport.php
@@ -12,10 +12,12 @@ use MBLSolutions\Report\Support\Enums\JobStatus;
 class RenderReport extends RenderReportJob
 {
 
-    public function __construct(string $uuid, Report $report, array $request = [])
+    public function __construct(string $uuid, Report $report, array $request = [], $authenticatable = null, string $schedule = null)
     {
         $this->report = $report;
         $this->request = $request;
+        $this->authenticatable = $authenticatable;
+        $this->schedule = $schedule;
         $this->chunkLimit = config('report.chunk_limit', 50000);
 
         $this->reportJob = $this->initiateRenderReportJob($uuid);
@@ -33,7 +35,9 @@ class RenderReport extends RenderReportJob
                 'status' => JobStatus::RUNNING,
                 'processed' => 0,
                 'total' => $this->getBuildReportService()->getTotalResults(),
-                'parameters' => json_encode($this->request, JSON_THROW_ON_ERROR | true)
+                'parameters' => json_encode($this->request, JSON_THROW_ON_ERROR | true),
+                'authenticatable_id' => $this->authenticatable,
+                'schedule_id' => $this->schedule,
             ]);
 
             ProcessReportExportChunk::dispatch($this->report, $this->reportJob, $this->request, 1);

--- a/src/Jobs/RenderReport.php
+++ b/src/Jobs/RenderReport.php
@@ -31,14 +31,19 @@ class RenderReport extends RenderReportJob
     public function handle(): void
     {
         try {
-            $this->reportJob->update([
+            $data = [
                 'status' => JobStatus::RUNNING,
                 'processed' => 0,
                 'total' => $this->getBuildReportService()->getTotalResults(),
                 'parameters' => json_encode($this->request, JSON_THROW_ON_ERROR | true),
-                'authenticatable_id' => $this->authenticatable,
                 'schedule_id' => $this->schedule,
-            ]);
+            ];
+
+            if ($this->authenticatable) {
+                $data['authenticatable_id'] = $this->authenticatable;
+            }
+
+            $this->reportJob->update($data);
 
             ProcessReportExportChunk::dispatch($this->report, $this->reportJob, $this->request, 1);
 

--- a/src/Jobs/RenderReportJob.php
+++ b/src/Jobs/RenderReportJob.php
@@ -21,6 +21,11 @@ abstract class RenderReportJob implements ShouldQueue
 
     public ReportJob $reportJob;
 
+    /** @var null|mixed */
+    public $authenticatable = null;
+
+    public ?string $schedule = null;
+
     public array $request;
 
     public int $chunkLimit = 50000;

--- a/src/Models/ScheduledReport.php
+++ b/src/Models/ScheduledReport.php
@@ -16,8 +16,13 @@ class ScheduledReport extends Model
 
     protected $primaryKey = 'uuid';
 
-    /** {@inheritDoc} */
     protected $guarded = [];
+
+    protected $casts = [
+        'parameters' => 'array',
+        'limit' => 'integer',
+        'created_at' => 'datetime'
+    ];
 
     /**
      * Belongs to a Report

--- a/src/Models/ScheduledReport.php
+++ b/src/Models/ScheduledReport.php
@@ -6,24 +6,18 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
-class ReportJob extends Model
+class ScheduledReport extends Model
 {
     use SoftDeletes;
-
-    protected $primaryKey = 'uuid';
 
     public $incrementing = false;
 
     protected $keyType = 'string';
 
+    protected $primaryKey = 'uuid';
+
     /** {@inheritDoc} */
     protected $guarded = [];
-
-
-    protected $casts = [
-        'processed' => 'integer',
-        'total' => 'integer',
-    ];
 
     /**
      * Belongs to a Report

--- a/src/Report.php
+++ b/src/Report.php
@@ -83,13 +83,13 @@ class Report
             Route::get('report/queue', 'QueuedReportController@index')->name('queue.index');
             Route::post('report/queue/{report}', 'QueuedReportController@render')->name('queue.render');
             Route::get('report/queue/job/{job}', 'QueuedReportController@job')->name('queue.job');
-            // TODO Route::get('report/queue/result/{job}', 'QueuedReportController@result')->name('queue.result');
             Route::get('report/queue/export/{job}', 'QueuedReportController@export')->name('queue.export');
 
             // Synchronous
             Route::get('report', 'ReportController@index')->name('index');
             Route::get('report/{report}', 'ReportController@show')->name('show');
             Route::post('report/{report}', 'ReportController@render')->name('render');
+            Route::post('report/{report}/preview', 'ReportController@preview')->name('preview');
 
             Route::post('report/{report}/export', 'ReportController@generateExport')->name('export');
         });

--- a/src/Report.php
+++ b/src/Report.php
@@ -73,6 +73,11 @@ class Report
             Route::get('report/data/type', 'DataTypeController@index')->name('data.type.list');
             Route::get('report/model', 'ModelController@index')->name('model.list');
 
+            // Scheduled Tasks
+            Route::get('report/schedule', 'ScheduledReportController@index')->name('schedule.index');
+            Route::post('report/schedule', 'ScheduledReportController@create')->name('schedule.create');
+            Route::delete('report/schedule/{schedule}', 'ScheduledReportController@destroy')->name('schedule.destroy');
+
             // Asynchronous
             Route::get('report/queue', 'QueuedReportController@index')->name('queue.index');
             Route::post('report/queue/{report}', 'QueuedReportController@render')->name('queue.render');

--- a/src/Report.php
+++ b/src/Report.php
@@ -74,6 +74,7 @@ class Report
             Route::get('report/model', 'ModelController@index')->name('model.list');
 
             // Scheduled Tasks
+            Route::get('report/schedule/frequency', 'ScheduledReportController@frequencies')->name('schedule.frequencies');
             Route::get('report/schedule', 'ScheduledReportController@index')->name('schedule.index');
             Route::post('report/schedule', 'ScheduledReportController@create')->name('schedule.create');
             Route::delete('report/schedule/{schedule}', 'ScheduledReportController@destroy')->name('schedule.destroy');

--- a/src/ReportServiceProvider.php
+++ b/src/ReportServiceProvider.php
@@ -3,6 +3,7 @@
 namespace MBLSolutions\Report;
 
 use Illuminate\Support\ServiceProvider;
+use MBLSolutions\Report\Console\Commands\DispatchScheduledReportsCommand;
 
 class ReportServiceProvider extends ServiceProvider
 {
@@ -25,6 +26,12 @@ class ReportServiceProvider extends ServiceProvider
         $this->publishes([
             __DIR__.'/../resources/js' => base_path('resources/js/report'),
         ], 'report-components');
+
+        if ($this->app->runningInConsole()) {
+            $this->commands([
+                DispatchScheduledReportsCommand::class
+            ]);
+        }
     }
 
     /**

--- a/src/Repositories/ReportJobRepository.php
+++ b/src/Repositories/ReportJobRepository.php
@@ -10,7 +10,7 @@ class ReportJobRepository
 {
 
     /**
-     * All Reports
+     * All Report Jobs
      *
      * @param int|null $limit
      * @return LengthAwarePaginator

--- a/src/Repositories/ReportJobRepository.php
+++ b/src/Repositories/ReportJobRepository.php
@@ -3,10 +3,12 @@
 namespace MBLSolutions\Report\Repositories;
 
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Carbon;
+use Lerouse\LaravelRepository\EloquentRepository;
 use MBLSolutions\Report\Models\ReportJob;
 
-class ReportJobRepository
+class ReportJobRepository extends EloquentRepository
 {
 
     /**
@@ -17,12 +19,18 @@ class ReportJobRepository
      */
     public function paginate(int $limit = null): LengthAwarePaginator
     {
-        return ReportJob::whereBetween('report_jobs.created_at', [
-            Carbon::now()->subDays(28)->toDateTimeString(),
-            Carbon::now()->toDateTimeString()
-        ])
-        ->orderByDesc('updated_at')
-        ->paginate($limit ?? null);
+        return $this->builder()
+                    ->whereBetween('report_jobs.created_at', [
+                        Carbon::now()->subDays(28)->toDateTimeString(),
+                        Carbon::now()->toDateTimeString()
+                    ])
+                    ->orderByDesc('updated_at')
+                    ->paginate($limit ?? null);
+    }
+
+    public function builder(): Builder
+    {
+       return ReportJob::query();
     }
 
 }

--- a/src/Repositories/ReportRepository.php
+++ b/src/Repositories/ReportRepository.php
@@ -3,20 +3,24 @@
 namespace MBLSolutions\Report\Repositories;
 
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Database\Eloquent\Builder;
+use Lerouse\LaravelRepository\EloquentRepository;
 use MBLSolutions\Report\Models\Report;
 
-class ReportRepository
+class ReportRepository extends EloquentRepository
 {
 
-    /**
-     * All Reports
-     *
-     * @param int|null $limit
-     * @return LengthAwarePaginator
-     */
     public function paginate(int $limit = null): LengthAwarePaginator
     {
-        return Report::where('active', '=', true)->orderBy('name')->paginate($limit ?? 25);
+        return $this->builder()
+                    ->where('active', '=', true)
+                    ->orderBy('name')
+                    ->paginate($limit ?? 25);
+    }
+
+    public function builder(): Builder
+    {
+        return Report::query();
     }
 
 }

--- a/src/Repositories/ScheduledReportRepository.php
+++ b/src/Repositories/ScheduledReportRepository.php
@@ -2,21 +2,56 @@
 
 namespace MBLSolutions\Report\Repositories;
 
+use Carbon\Carbon;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Collection;
+use Lerouse\LaravelRepository\EloquentRepository;
 use MBLSolutions\Report\Models\ScheduledReport;
+use MBLSolutions\Report\Support\Enums\ReportSchedule;
 
-class ScheduledReportRepository
+class ScheduledReportRepository extends EloquentRepository
 {
+    
+    public function getScheduledReportsToRun(Carbon $date): Collection
+    {
+        $frequencies = collect([]);
 
-    /**
-     * All Scheduled Reports
-     *
-     * @param int|null $limit
-     * @return LengthAwarePaginator
-     */
+        if ($date->format('i:s') === '00:00') {
+            $frequencies->push(ReportSchedule::HOURLY);
+        }
+
+        if ($date->format('H:i:s') === '00:00:00') {
+            $frequencies->push(ReportSchedule::DAILY);
+        }
+
+        if ($date->format('l H:i:s') === 'Monday 00:00:00') {
+            $frequencies->push(ReportSchedule::WEEKLY);
+        }
+
+        if ($date->format('d H:i:s') === '01 00:00:00') {
+            $frequencies->push(ReportSchedule::MONTHLY);
+        }
+
+        if ($date->format('d H:i:s') === '01 00:00:00' && in_array($date->format('m'), ['01', '04', '07', '10'])) {
+            $frequencies->push(ReportSchedule::QUARTERLY);
+        }
+
+        if ($date->format('m-d H:i:s') === '01-01 00:00:00') {
+            $frequencies->push(ReportSchedule::YEARLY);
+        }
+
+        return $this->builder()->whereIn('scheduled_reports.frequency', $frequencies->toArray())->get();
+    }
+
     public function paginate(int $limit = null): LengthAwarePaginator
     {
-        return ScheduledReport::orderByDesc('updated_at')->paginate($limit ?? null);
+        return $this->builder()->orderByDesc('updated_at')->paginate($limit ?? null);
+    }
+
+    public function builder(): Builder
+    {
+        return ScheduledReport::query();
     }
 
 }

--- a/src/Repositories/ScheduledReportRepository.php
+++ b/src/Repositories/ScheduledReportRepository.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace MBLSolutions\Report\Repositories;
+
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use MBLSolutions\Report\Models\ScheduledReport;
+
+class ScheduledReportRepository
+{
+
+    /**
+     * All Scheduled Reports
+     *
+     * @param int|null $limit
+     * @return LengthAwarePaginator
+     */
+    public function paginate(int $limit = null): LengthAwarePaginator
+    {
+        return ScheduledReport::orderByDesc('updated_at')->paginate($limit ?? null);
+    }
+
+}

--- a/src/Services/QueuedReportExportService.php
+++ b/src/Services/QueuedReportExportService.php
@@ -19,29 +19,38 @@ class QueuedReportExportService
 
     public function getExportResponse(): Collection
     {
-        $links = collect([]);
-
-        $path = config('report.filesystem_path', 'reports/') . $this->job->getKey();
-
-        $files = Storage::disk(config('report.filesystem'))->allFiles($path);
-
-
-        foreach ($files as $file) {
-            $links->push(
-                $this->createExportLink($file)
-            );
-        }
-
         return new Collection([
             'name' => $this->job->report->getAttribute('name'),
             'date' => $this->job->getAttribute('created_at'),
             'uuid' => $this->job->getKey(),
             'total' => $this->job->getAttribute('total'),
             'chunk_limit' => config('report.chunk_limit', 50000),
-            'urls' => $links->toArray()
+            'urls' => $this->getExportLinks()->toArray()
         ]);
     }
 
+    /**
+     * Get Export Links
+     *
+     * @return Collection
+     */
+    public function getExportLinks(): Collection
+    {
+        $links = new Collection([]);
+
+        foreach ($this->getExportFiles() as $file) {
+            $links->push($this->createExportLink($file));
+        }
+
+        return $links;
+    }
+
+    /**
+     * Create export link
+     *
+     * @param string $path
+     * @return array
+     */
     protected function createExportLink(string $path): array
     {
         $name = $this->getFileName($path);
@@ -72,6 +81,18 @@ class QueuedReportExportService
     protected function getFileName(string $path)
     {
         return substr(strrchr($path, '/'), 1);
+    }
+
+    /**
+     * Get export Files
+     *
+     * @return array
+     */
+    protected function getExportFiles(): array
+    {
+        $path = config('report.filesystem_path', 'reports/') . $this->job->getKey();
+
+        return Storage::disk(config('report.filesystem'))->allFiles($path);
     }
 
 }

--- a/src/Support/EnumModel.php
+++ b/src/Support/EnumModel.php
@@ -13,13 +13,43 @@ abstract class EnumModel
      * Get All Enumerators
      *
      * @return Collection
-     * @throws ReflectionException
      */
     public static function all(): Collection
     {
         $reflectionClass = new ReflectionClass(static::class);
 
         return collect($reflectionClass->getConstants());
+    }
+
+    /**
+     * Get a Readable name for the ENUM
+     *
+     * @param string $enum
+     * @return string
+     */
+    public static function name(string $enum): string
+    {
+        $parts = array_map('ucfirst', explode('_', $enum));
+
+        return implode('', $parts);
+    }
+
+    /**
+     * Collection of Options
+     *
+     * @param string $value
+     * @param string $name
+     * @return Collection
+     */
+    public static function options(string $value = 'id', string $name = 'name'): Collection
+    {
+        $options = collect();
+
+        self::all()->each(static function ($enum) use ($options) {
+            $options->add(['id' => $enum, 'name' => self::name($enum)]);
+        });
+
+        return $options;
     }
 
 }

--- a/src/Support/Enums/ReportSchedule.php
+++ b/src/Support/Enums/ReportSchedule.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace MBLSolutions\Report\Support\Enums;
+
+use MBLSolutions\Report\Support\EnumModel;
+
+class ReportSchedule extends EnumModel
+{
+    public const HOURLY = 'hourly';
+
+    public const DAILY = 'daily';
+
+    public const WEEKLY = 'weekly';
+
+    public const MONTHLY = 'monthly';
+
+    public const QUARTERLY = 'quarterly';
+
+    public const YEARLY = 'yearly';
+
+}

--- a/tests/Feature/ManageReportControllerTest.php
+++ b/tests/Feature/ManageReportControllerTest.php
@@ -11,8 +11,6 @@ class ManageReportControllerTest extends LaravelTestCase
     /** @test **/
     public function can_view_manage_report_index(): void
     {
-        $this->withoutExceptionHandling();
-
         factory(Report::class)->create(['name' => 'Test Report']);
 
         $response = $this->getJson(route('report.manage.index'));

--- a/tests/Feature/QueuedReportControllerTest.php
+++ b/tests/Feature/QueuedReportControllerTest.php
@@ -75,8 +75,6 @@ class QueuedReportControllerTest extends LaravelTestCase
     /** @test **/
     public function can_generate_export_link(): void
     {
-        $this->withoutExceptionHandling();
-
         Storage::fake();
 
         factory(ReportJob::class)->create([

--- a/tests/Feature/ReportControllerTest.php
+++ b/tests/Feature/ReportControllerTest.php
@@ -109,4 +109,14 @@ class ReportControllerTest extends LaravelTestCase
         $response->assertStatus(401);
     }
 
+    /** @test **/
+    public function can_view_report_preview(): void
+    {
+        $this->withoutExceptionHandling();
+
+        $this->postJson(route('report.preview', [
+            'report' => factory(Report::class)->create()
+        ]), [])->assertStatus(200);
+    }
+
 }

--- a/tests/Feature/ScheduledReportControllerTest.php
+++ b/tests/Feature/ScheduledReportControllerTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace MBLSolutions\Report\Tests\Feature;
+
+use MBLSolutions\Report\Models\Report;
+use MBLSolutions\Report\Models\ScheduledReport;
+use MBLSolutions\Report\Support\Enums\ReportSchedule;
+use MBLSolutions\Report\Tests\LaravelTestCase;
+
+class ScheduledReportControllerTest extends LaravelTestCase
+{
+
+    /** @test **/
+    public function can_view_scheduled_report_index(): void
+    {
+        $this->getJson(route('report.schedule.index'))->assertStatus(200);
+    }
+
+    /** @test **/
+    public function can_create_scheduled_report(): void
+    {
+        $this->withoutExceptionHandling();
+
+        $this->postJson(route('report.schedule.create'), [
+            'schedule' => ReportSchedule::MONTHLY,
+            'report_id' => factory(Report::class)->create()->getKey(),
+            'authenticatable_id' => null,
+            'parameters' => null,
+        ])->assertStatus(201);
+    }
+
+    /** @test **/
+    public function can_delete_scheduled_report(): void
+    {
+        $this->deleteJson(route('report.schedule.destroy', [
+            'schedule' => factory(ScheduledReport::class)->create()
+        ]))->assertStatus(204);
+    }
+
+}

--- a/tests/Feature/ScheduledReportControllerTest.php
+++ b/tests/Feature/ScheduledReportControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace MBLSolutions\Report\Tests\Feature;
 
+use MBLSolutions\Report\Driver\QueuedExport\CsvQueuedExport;
 use MBLSolutions\Report\Models\Report;
 use MBLSolutions\Report\Models\ScheduledReport;
 use MBLSolutions\Report\Support\Enums\ReportSchedule;
@@ -19,13 +20,14 @@ class ScheduledReportControllerTest extends LaravelTestCase
     /** @test **/
     public function can_create_scheduled_report(): void
     {
-        $this->withoutExceptionHandling();
-
         $this->postJson(route('report.schedule.create'), [
-            'schedule' => ReportSchedule::MONTHLY,
             'report_id' => factory(Report::class)->create()->getKey(),
+            'parameters' => ['export_driver' => CsvQueuedExport::class],
+            'frequency' => ReportSchedule::MONTHLY,
+            'limit' => null,
+            'recipients' => null,
+            'last_run' => null,
             'authenticatable_id' => null,
-            'parameters' => null,
         ])->assertStatus(201);
     }
 

--- a/tests/LaravelTestCase.php
+++ b/tests/LaravelTestCase.php
@@ -55,6 +55,7 @@ class LaravelTestCase extends OTBTestCase
         );
         $app['config']->set('report.filesystem', $config['filesystem']);
         $app['config']->set('report.filesystem_path', $config['filesystem_path']);
+        $app['config']->set('report.preview_limit', $config['preview_limit']);
 
     }
 

--- a/tests/Unit/Console/Commands/DispatchScheduleReportsCommendDispatchTest.php
+++ b/tests/Unit/Console/Commands/DispatchScheduleReportsCommendDispatchTest.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace MBLSolutions\Report\Tests\Unit\Console\Commands;
+
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Event;
+use MBLSolutions\Report\Events\ScheduledReportDispatched;
+use MBLSolutions\Report\Models\Report;
+use MBLSolutions\Report\Models\ScheduledReport;
+use MBLSolutions\Report\Support\Enums\ReportSchedule;
+use MBLSolutions\Report\Tests\LaravelTestCase;
+
+class DispatchScheduleReportsCommendDispatchTest extends LaravelTestCase
+{
+    protected Report $report;
+
+    /** {@inheritdoc} **/
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Bus::fake();
+        Event::fake();
+
+        $this->report = factory(Report::class)->create();
+
+        factory(ScheduledReport::class)->create([
+            'uuid' => 'd68a28d3-8544-4dd2-aeed-ed148eb37874',
+            'frequency' => ReportSchedule::HOURLY,
+            'report_id' => $this->report->getKey()
+        ]);
+
+        factory(ScheduledReport::class)->create([
+            'uuid' => 'c066524b-b5ad-46d1-961d-f96203c54181',
+            'frequency' => ReportSchedule::DAILY,
+            'report_id' => $this->report->getKey()
+        ]);
+
+        factory(ScheduledReport::class)->create([
+            'uuid' => '404a1dbc-226a-46bd-9348-de2dd28f8d56',
+            'frequency' => ReportSchedule::WEEKLY,
+            'report_id' => $this->report->getKey()
+        ]);
+
+        factory(ScheduledReport::class)->create([
+            'uuid' => '56738a7e-4bec-4c14-a8f7-7ef0ea58f204',
+            'frequency' => ReportSchedule::MONTHLY,
+            'report_id' => $this->report->getKey()
+        ]);
+
+        factory(ScheduledReport::class)->create([
+            'uuid' => '417aa61e-3219-422d-9111-f701daf7e18f',
+            'frequency' => ReportSchedule::QUARTERLY,
+            'report_id' => $this->report->getKey()
+        ]);
+
+        factory(ScheduledReport::class)->create([
+            'uuid' => '2930826c-6732-44e6-9c19-f62153ad53a9',
+            'frequency' => ReportSchedule::YEARLY,
+            'report_id' => $this->report->getKey()
+        ]);
+    }
+
+    /** @test **/
+    public function can_run_hourly_schedule(): void
+    {
+        Carbon::setTestNow('2021-11-10 09:00:00'); // on the hour (Wednesday)
+
+        $this->artisan('report:schedule');
+
+        $this->assertScheduledEventDispatch('d68a28d3-8544-4dd2-aeed-ed148eb37874');
+        $this->assertScheduledEventNotDispatched('c066524b-b5ad-46d1-961d-f96203c54181');
+        $this->assertScheduledEventNotDispatched('404a1dbc-226a-46bd-9348-de2dd28f8d56');
+        $this->assertScheduledEventNotDispatched('56738a7e-4bec-4c14-a8f7-7ef0ea58f204');
+        $this->assertScheduledEventNotDispatched('417aa61e-3219-422d-9111-f701daf7e18f');
+        $this->assertScheduledEventNotDispatched('2930826c-6732-44e6-9c19-f62153ad53a9');
+    }
+
+    /** @test **/
+    public function can_run_daily_schedule(): void
+    {
+        Carbon::setTestNow('2021-11-10 00:00:00'); // daily at midnight (Wednesday)
+
+        $this->artisan('report:schedule');
+
+        $this->assertScheduledEventDispatch('d68a28d3-8544-4dd2-aeed-ed148eb37874');
+        $this->assertScheduledEventDispatch('c066524b-b5ad-46d1-961d-f96203c54181');
+        $this->assertScheduledEventNotDispatched('404a1dbc-226a-46bd-9348-de2dd28f8d56');
+        $this->assertScheduledEventNotDispatched('56738a7e-4bec-4c14-a8f7-7ef0ea58f204');
+        $this->assertScheduledEventNotDispatched('417aa61e-3219-422d-9111-f701daf7e18f');
+        $this->assertScheduledEventNotDispatched('2930826c-6732-44e6-9c19-f62153ad53a9');
+    }
+
+    /** @test **/
+    public function can_run_weekly_schedule(): void
+    {
+        Carbon::setTestNow('2021-02-08 00:00:00'); // weekly at midnight on a Monday (Monday)
+
+        $this->artisan('report:schedule');
+
+        $this->assertScheduledEventDispatch('d68a28d3-8544-4dd2-aeed-ed148eb37874');
+        $this->assertScheduledEventDispatch('c066524b-b5ad-46d1-961d-f96203c54181');
+        $this->assertScheduledEventDispatch('404a1dbc-226a-46bd-9348-de2dd28f8d56');
+        $this->assertScheduledEventNotDispatched('56738a7e-4bec-4c14-a8f7-7ef0ea58f204');
+        $this->assertScheduledEventNotDispatched('417aa61e-3219-422d-9111-f701daf7e18f');
+        $this->assertScheduledEventNotDispatched('2930826c-6732-44e6-9c19-f62153ad53a9');
+    }
+
+    /** @test **/
+    public function can_run_monthly_schedule(): void
+    {
+        Carbon::setTestNow('2021-05-01 00:00:00'); // monthly on the first of the month (Saturday)
+
+        $this->artisan('report:schedule');
+
+        $this->assertScheduledEventDispatch('d68a28d3-8544-4dd2-aeed-ed148eb37874');
+        $this->assertScheduledEventDispatch('c066524b-b5ad-46d1-961d-f96203c54181');
+        $this->assertScheduledEventNotDispatched('404a1dbc-226a-46bd-9348-de2dd28f8d56');
+        $this->assertScheduledEventDispatch('56738a7e-4bec-4c14-a8f7-7ef0ea58f204');
+        $this->assertScheduledEventNotDispatched('417aa61e-3219-422d-9111-f701daf7e18f');
+        $this->assertScheduledEventNotDispatched('2930826c-6732-44e6-9c19-f62153ad53a9');
+    }
+
+    /** @test **/
+    public function can_run_quarterly_schedule(): void
+    {
+        Carbon::setTestNow('2021-04-01 00:00:00'); // quarterly on the first of the start of the next quarter (Thursday 1st April)
+
+        $this->artisan('report:schedule');
+
+        $this->assertScheduledEventDispatch('d68a28d3-8544-4dd2-aeed-ed148eb37874');
+        $this->assertScheduledEventDispatch('c066524b-b5ad-46d1-961d-f96203c54181');
+        $this->assertScheduledEventNotDispatched('404a1dbc-226a-46bd-9348-de2dd28f8d56');
+        $this->assertScheduledEventDispatch('56738a7e-4bec-4c14-a8f7-7ef0ea58f204');
+        $this->assertScheduledEventDispatch('417aa61e-3219-422d-9111-f701daf7e18f');
+        $this->assertScheduledEventNotDispatched('2930826c-6732-44e6-9c19-f62153ad53a9');
+    }
+
+    /** @test **/
+    public function can_run_yearly_schedule(): void
+    {
+        Carbon::setTestNow('2021-01-01 00:00:00'); // first of every year (Friday)
+
+        $this->artisan('report:schedule');
+
+        $this->assertScheduledEventDispatch('d68a28d3-8544-4dd2-aeed-ed148eb37874');
+        $this->assertScheduledEventDispatch('c066524b-b5ad-46d1-961d-f96203c54181');
+        $this->assertScheduledEventNotDispatched('404a1dbc-226a-46bd-9348-de2dd28f8d56');
+        $this->assertScheduledEventDispatch('56738a7e-4bec-4c14-a8f7-7ef0ea58f204');
+        $this->assertScheduledEventDispatch('417aa61e-3219-422d-9111-f701daf7e18f');
+        $this->assertScheduledEventDispatch('2930826c-6732-44e6-9c19-f62153ad53a9');
+    }
+
+    protected function assertScheduledEventDispatch(string $uuid): void
+    {
+        try {
+            Event::assertDispatched(ScheduledReportDispatched::class, fn ($event) => $this->eventsUuidMatches($event, $uuid));
+        } catch (\Exception $exception) {
+            $this->fail(
+                sprintf('Failed asserting event was dispatched for %s', $uuid)
+            );
+        }
+    }
+
+    protected function assertScheduledEventNotDispatched(string $uuid): void
+    {
+        try {
+            Event::assertNotDispatched(ScheduledReportDispatched::class, fn ($event) => $this->eventsUuidMatches($event, $uuid, true));
+        } catch (\Exception $exception) {
+            $this->fail(
+                sprintf('Failed asserting event was NOT dispatched for %s', $uuid)
+            );
+        }
+    }
+
+    private function eventsUuidMatches($event, $uuid, bool $condition = true): bool
+    {
+        if ($condition === true) {
+            return $event->schedule->getKey() === $uuid;
+        }
+
+        return $event->schedule->getKey() !== $uuid;
+    }
+
+}

--- a/tests/Unit/Console/Commands/DispatchScheduledReportsCommandTest.php
+++ b/tests/Unit/Console/Commands/DispatchScheduledReportsCommandTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace MBLSolutions\Report\Tests\Unit\Console\Commands;
+
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Bus;
+use MBLSolutions\Report\Jobs\RenderReport;
+use MBLSolutions\Report\Models\Report;
+use MBLSolutions\Report\Models\ScheduledReport;
+use MBLSolutions\Report\Tests\LaravelTestCase;
+
+class DispatchScheduledReportsCommandTest extends LaravelTestCase
+{
+    protected Report $report;
+    
+    /** {@inheritdoc} **/
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Bus::fake();
+
+        $this->report = factory(Report::class)->create();
+    }
+    
+    /** @test **/
+    public function can_run_command(): void
+    {
+        $this->artisan('report:schedule')->assertExitCode(0);
+    }
+
+    /** @test **/
+    public function can_run_scheduled_report(): void
+    {
+        Carbon::setTestNow('2021-05-01 00:00:00');
+
+        factory(ScheduledReport::class)->create([
+            'report_id' => $this->report->getKey()
+        ]);
+
+        $this->artisan('report:schedule');
+
+        Bus::assertDispatched(RenderReport::class, function ($job) {
+            return $job->report->getKey() === $this->report->getKey();
+        });
+    }
+
+}

--- a/tests/Unit/Repositories/ScheduledReportRepositoryTest.php
+++ b/tests/Unit/Repositories/ScheduledReportRepositoryTest.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace MBLSolutions\Report\Tests\Unit\Repositories;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Event;
+use MBLSolutions\Report\Models\Report;
+use MBLSolutions\Report\Models\ScheduledReport;
+use MBLSolutions\Report\Repositories\ScheduledReportRepository;
+use MBLSolutions\Report\Support\Enums\ReportSchedule;
+use MBLSolutions\Report\Tests\LaravelTestCase;
+
+class ScheduledReportRepositoryTest extends LaravelTestCase
+{
+    use RefreshDatabase;
+
+    protected ScheduledReportRepository $repository;
+
+    protected Report $report;
+
+    /** {@inheritdoc} **/
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Bus::fake();
+        Event::fake();
+
+        $this->repository = new ScheduledReportRepository();
+        $this->report = factory(Report::class)->create();
+
+        factory(ScheduledReport::class)->create([
+            'uuid' => 'd68a28d3-8544-4dd2-aeed-ed148eb37874',
+            'frequency' => ReportSchedule::HOURLY,
+            'report_id' => $this->report->getKey()
+        ]);
+
+        factory(ScheduledReport::class)->create([
+            'uuid' => 'c066524b-b5ad-46d1-961d-f96203c54181',
+            'frequency' => ReportSchedule::DAILY,
+            'report_id' => $this->report->getKey()
+        ]);
+
+        factory(ScheduledReport::class)->create([
+            'uuid' => '404a1dbc-226a-46bd-9348-de2dd28f8d56',
+            'frequency' => ReportSchedule::WEEKLY,
+            'report_id' => $this->report->getKey()
+        ]);
+
+        factory(ScheduledReport::class)->create([
+            'uuid' => '56738a7e-4bec-4c14-a8f7-7ef0ea58f204',
+            'frequency' => ReportSchedule::MONTHLY,
+            'report_id' => $this->report->getKey()
+        ]);
+
+        factory(ScheduledReport::class)->create([
+            'uuid' => '417aa61e-3219-422d-9111-f701daf7e18f',
+            'frequency' => ReportSchedule::QUARTERLY,
+            'report_id' => $this->report->getKey()
+        ]);
+
+        factory(ScheduledReport::class)->create([
+            'uuid' => '2930826c-6732-44e6-9c19-f62153ad53a9',
+            'frequency' => ReportSchedule::YEARLY,
+            'report_id' => $this->report->getKey()
+        ]);
+    }
+
+    /** @test **/
+    public function can_run_hourly_schedule(): void
+    {
+        $date = Carbon::parse('2021-11-10 09:00:00'); // on the hour (Wednesday)
+
+        $this->assertEquals([
+            'd68a28d3-8544-4dd2-aeed-ed148eb37874', // HOURLY
+        ], $this->repository->getScheduledReportsToRun($date)->pluck('uuid')->toArray());
+    }
+
+    /** @test **/
+    public function can_run_daily_schedule(): void
+    {
+        $date = Carbon::parse('2021-11-10 00:00:00'); // daily at midnight (Wednesday)
+
+        $this->assertEquals([
+            'c066524b-b5ad-46d1-961d-f96203c54181', // DAILY
+            'd68a28d3-8544-4dd2-aeed-ed148eb37874', // HOURLY
+        ], $this->repository->getScheduledReportsToRun($date)->pluck('uuid')->toArray());
+    }
+
+    /** @test **/
+    public function can_run_weekly_schedule(): void
+    {
+        $date = Carbon::parse('2021-02-08 00:00:00'); // weekly at midnight on a Monday (Monday)
+
+        $this->assertEquals([
+            'c066524b-b5ad-46d1-961d-f96203c54181', // DAILY
+            'd68a28d3-8544-4dd2-aeed-ed148eb37874', // HOURLY
+            '404a1dbc-226a-46bd-9348-de2dd28f8d56', // WEEKLY
+        ], $this->repository->getScheduledReportsToRun($date)->pluck('uuid')->toArray());
+    }
+
+    /** @test **/
+    public function can_run_monthly_schedule(): void
+    {
+        $date = Carbon::parse('2021-05-01 00:00:00'); // monthly on the first of the month (Saturday)
+
+        $this->assertEquals([
+            'c066524b-b5ad-46d1-961d-f96203c54181', // DAILY
+            'd68a28d3-8544-4dd2-aeed-ed148eb37874', // HOURLY
+            '56738a7e-4bec-4c14-a8f7-7ef0ea58f204', // MONTHLY
+        ], $this->repository->getScheduledReportsToRun($date)->pluck('uuid')->toArray());
+    }
+
+    /** @test **/
+    public function can_run_quarterly_schedule(): void
+    {
+        $date = Carbon::parse('2021-04-01 00:00:00'); // quarterly on the first of the start of the next quarter (Thursday 1st April)
+
+        $this->assertEquals([
+            'c066524b-b5ad-46d1-961d-f96203c54181', // DAILY
+            'd68a28d3-8544-4dd2-aeed-ed148eb37874', // HOURLY
+            '56738a7e-4bec-4c14-a8f7-7ef0ea58f204', // MONTHLY
+            '417aa61e-3219-422d-9111-f701daf7e18f', // QUARTERLY
+        ], $this->repository->getScheduledReportsToRun($date)->pluck('uuid')->toArray());
+    }
+
+    /** @test **/
+    public function can_run_yearly_schedule(): void
+    {
+        $date = Carbon::parse('2021-01-01 00:00:00'); // first of every year (Friday)
+
+        $this->assertEquals([
+            'c066524b-b5ad-46d1-961d-f96203c54181', // DAILY
+            'd68a28d3-8544-4dd2-aeed-ed148eb37874', // HOURLY
+            '56738a7e-4bec-4c14-a8f7-7ef0ea58f204', // MONTHLY
+            '417aa61e-3219-422d-9111-f701daf7e18f', // QUARTERLY
+            '2930826c-6732-44e6-9c19-f62153ad53a9', // YEARLY
+        ], $this->repository->getScheduledReportsToRun($date)->pluck('uuid')->toArray());
+    }
+
+}

--- a/tests/database/factories/ModelFactory.php
+++ b/tests/database/factories/ModelFactory.php
@@ -6,6 +6,7 @@ use Faker\Generator as Faker;
 use Illuminate\Database\Eloquent\Factory;
 use Illuminate\Support\Str;
 use MBLSolutions\Report\DataType\CastTitleCaseString;
+use MBLSolutions\Report\Driver\QueuedExport\CsvQueuedExport;
 use MBLSolutions\Report\Models\Report;
 use MBLSolutions\Report\Models\ReportField;
 use MBLSolutions\Report\Models\ReportJob;
@@ -14,6 +15,7 @@ use MBLSolutions\Report\Models\ReportMiddleware;
 use MBLSolutions\Report\Models\ScheduledReport;
 use MBLSolutions\Report\Models\ReportSelect;
 use MBLSolutions\Report\Support\Enums\JobStatus;
+use MBLSolutions\Report\Support\Enums\ReportSchedule;
 use MBLSolutions\Report\Tests\Fakes\Middleware\FakeMiddleware;
 
 $factory->define(Report::class, static function (Faker $faker) {
@@ -35,7 +37,9 @@ $factory->define(Report::class, static function (Faker $faker) {
 
 $factory->define(ReportSelect::class, static function (Faker $faker) {
     return [
-        'report_id' => factory(Report::class)->create(),
+        'report_id' => function () {
+            return factory(Report::class)->create();
+        },
         'column' => 'name',
         'alias' => 'user_name',
         'type' => CastTitleCaseString::class,
@@ -45,7 +49,9 @@ $factory->define(ReportSelect::class, static function (Faker $faker) {
 
 $factory->define(ReportJoin::class, static function (Faker $faker) {
     return [
-        'report_id' => factory(Report::class)->create(),
+        'report_id' => function () {
+            return factory(Report::class)->create();
+        },
         'type' => 'left_join',
         'table' => 'posts',
         'first' => 'users.id',
@@ -56,14 +62,18 @@ $factory->define(ReportJoin::class, static function (Faker $faker) {
 
 $factory->define(ReportMiddleware::class, static function (Faker $faker) {
     return array(
-        'report_id' => factory(Report::class)->create(),
+        'report_id' => function () {
+            return factory(Report::class)->create();
+        },
         'middleware' => FakeMiddleware::class
     );
 });
 
 $factory->define(ReportField::class, static function (Faker $faker) {
     return [
-        'report_id' => factory(Report::class)->create(),
+        'report_id' => function () {
+            return factory(Report::class)->create();
+        },
         'label' => 'Created At',
         'type' => 'datetime',
         'model' => null,
@@ -87,10 +97,16 @@ $factory->define(ReportJob::class, static function (Faker $faker) {
 $factory->define(ScheduledReport::class, static function (Faker $faker) {
     return [
         'uuid' => Str::uuid(),
-        'schedule' => \MBLSolutions\Report\Support\Enums\ReportSchedule::MONTHLY,
-        'report_id' => factory(Report::class)->create(),
-        'authenticatable_id' => null,
-        'parameters' => null,
+        'report_id' => function () {
+            return factory(Report::class)->create();
+        },
+        'parameters' => [
+            'export_driver' => CsvQueuedExport::class
+        ],
+        'frequency' => ReportSchedule::MONTHLY,
+        'limit' => null,
+        'recipients' => null,
         'last_run' => null,
+        'authenticatable_id' => null,
     ];
 });

--- a/tests/database/factories/ModelFactory.php
+++ b/tests/database/factories/ModelFactory.php
@@ -91,6 +91,7 @@ $factory->define(ReportJob::class, static function (Faker $faker) {
         },
         'status' => JobStatus::SCHEDULED,
         'authenticatable_id' => null,
+        'schedule_id' => null,
     ];
 });
 

--- a/tests/database/factories/ModelFactory.php
+++ b/tests/database/factories/ModelFactory.php
@@ -11,6 +11,7 @@ use MBLSolutions\Report\Models\ReportField;
 use MBLSolutions\Report\Models\ReportJob;
 use MBLSolutions\Report\Models\ReportJoin;
 use MBLSolutions\Report\Models\ReportMiddleware;
+use MBLSolutions\Report\Models\ScheduledReport;
 use MBLSolutions\Report\Models\ReportSelect;
 use MBLSolutions\Report\Support\Enums\JobStatus;
 use MBLSolutions\Report\Tests\Fakes\Middleware\FakeMiddleware;
@@ -80,5 +81,16 @@ $factory->define(ReportJob::class, static function (Faker $faker) {
         },
         'status' => JobStatus::SCHEDULED,
         'authenticatable_id' => null,
+    ];
+});
+
+$factory->define(ScheduledReport::class, static function (Faker $faker) {
+    return [
+        'uuid' => Str::uuid(),
+        'schedule' => \MBLSolutions\Report\Support\Enums\ReportSchedule::MONTHLY,
+        'report_id' => factory(Report::class)->create(),
+        'authenticatable_id' => null,
+        'parameters' => null,
+        'last_run' => null,
     ];
 });


### PR DESCRIPTION
## v2.4.0

+ Add scheduled report migration
+ Add scheduled report model
+ Add scheduled report routes
  + GET /report/schedule
  + POST /report/schedule
  + DELETE /report/schedule/{schedule}
+ Add new Command `\MBLSolutions\Report\Console\Commands\DispatchScheduledReportsCommand::class`
+ Add a report render preview, limited to 1000 results (can be overridden use the `REPORT_PREVIEW_LIMIT` env)