### PR TITLE
v2.6.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+## v2.6.0
+
++ Remove hourly from report schedule due to complexities on time based replacements (to be added back in once time permits)
++ Apply date filtering to scheduled reports 
+  + e.g. Today 2021-01-01 00:00:00 (daily report would replace parameters start_date 2020-12-31 00:00:00 end_date 2020-12-31 23:59:59)
+
 ## v2.5.0
 
 + Add report schedule show and update routes

--- a/src/Console/Commands/DispatchScheduledReportsCommand.php
+++ b/src/Console/Commands/DispatchScheduledReportsCommand.php
@@ -44,7 +44,7 @@ class DispatchScheduledReportsCommand extends Command
 
             Bus::dispatch(
                 new RenderReport(
-                    $uuid, $report, $schedule->getAttribute('parameters'), $schedule->getAttribute('authenticatable_id'), $schedule->getKey()
+                    $uuid, $report, $schedule->getAttribute('parameters'), $schedule->getAttribute('authenticatable_id'), $schedule
                 )
             );
 

--- a/src/Jobs/RenderReportJob.php
+++ b/src/Jobs/RenderReportJob.php
@@ -10,6 +10,7 @@ use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use MBLSolutions\Report\Models\Report;
 use MBLSolutions\Report\Models\ReportJob;
+use MBLSolutions\Report\Models\ScheduledReport;
 use MBLSolutions\Report\Services\BuildReportService;
 use MBLSolutions\Report\Support\Enums\JobStatus;
 
@@ -24,7 +25,7 @@ abstract class RenderReportJob implements ShouldQueue
     /** @var null|mixed */
     public $authenticatable = null;
 
-    public ?string $schedule = null;
+    public ?ScheduledReport $schedule = null;
 
     public array $request;
 

--- a/src/Repositories/ScheduledReportRepository.php
+++ b/src/Repositories/ScheduledReportRepository.php
@@ -17,10 +17,6 @@ class ScheduledReportRepository extends EloquentRepository
     {
         $frequencies = new Collection([]);
 
-        if ($date->format('i') === '00') {
-            $frequencies->push(ReportSchedule::HOURLY);
-        }
-
         if ($date->format('H:i') === '00:00') {
             $frequencies->push(ReportSchedule::DAILY);
         }

--- a/src/Support/Enums/ReportSchedule.php
+++ b/src/Support/Enums/ReportSchedule.php
@@ -6,8 +6,6 @@ use MBLSolutions\Report\Support\EnumModel;
 
 class ReportSchedule extends EnumModel
 {
-    public const HOURLY = 'hourly';
-
     public const DAILY = 'daily';
 
     public const WEEKLY = 'weekly';

--- a/tests/LaravelTestCase.php
+++ b/tests/LaravelTestCase.php
@@ -56,6 +56,8 @@ class LaravelTestCase extends OTBTestCase
         $app['config']->set('report.filesystem', $config['filesystem']);
         $app['config']->set('report.filesystem_path', $config['filesystem_path']);
         $app['config']->set('report.preview_limit', $config['preview_limit']);
+        $app['config']->set('report.scheduled_date_start', $config['scheduled_date_start']);
+        $app['config']->set('report.scheduled_date_end', $config['scheduled_date_end']);
 
     }
 

--- a/tests/Unit/Console/Commands/DispatchScheduleReportsCommendDispatchTest.php
+++ b/tests/Unit/Console/Commands/DispatchScheduleReportsCommendDispatchTest.php
@@ -26,12 +26,6 @@ class DispatchScheduleReportsCommendDispatchTest extends LaravelTestCase
         $this->report = factory(Report::class)->create();
 
         factory(ScheduledReport::class)->create([
-            'uuid' => 'd68a28d3-8544-4dd2-aeed-ed148eb37874',
-            'frequency' => ReportSchedule::HOURLY,
-            'report_id' => $this->report->getKey()
-        ]);
-
-        factory(ScheduledReport::class)->create([
             'uuid' => 'c066524b-b5ad-46d1-961d-f96203c54181',
             'frequency' => ReportSchedule::DAILY,
             'report_id' => $this->report->getKey()
@@ -63,28 +57,12 @@ class DispatchScheduleReportsCommendDispatchTest extends LaravelTestCase
     }
 
     /** @test **/
-    public function can_run_hourly_schedule(): void
-    {
-        Carbon::setTestNow('2021-11-10 09:00:00'); // on the hour (Wednesday)
-
-        $this->artisan('report:schedule');
-
-        $this->assertScheduledEventDispatch('d68a28d3-8544-4dd2-aeed-ed148eb37874');
-        $this->assertScheduledEventNotDispatched('c066524b-b5ad-46d1-961d-f96203c54181');
-        $this->assertScheduledEventNotDispatched('404a1dbc-226a-46bd-9348-de2dd28f8d56');
-        $this->assertScheduledEventNotDispatched('56738a7e-4bec-4c14-a8f7-7ef0ea58f204');
-        $this->assertScheduledEventNotDispatched('417aa61e-3219-422d-9111-f701daf7e18f');
-        $this->assertScheduledEventNotDispatched('2930826c-6732-44e6-9c19-f62153ad53a9');
-    }
-
-    /** @test **/
     public function can_run_daily_schedule(): void
     {
         Carbon::setTestNow('2021-11-10 00:00:00'); // daily at midnight (Wednesday)
 
         $this->artisan('report:schedule');
 
-        $this->assertScheduledEventDispatch('d68a28d3-8544-4dd2-aeed-ed148eb37874');
         $this->assertScheduledEventDispatch('c066524b-b5ad-46d1-961d-f96203c54181');
         $this->assertScheduledEventNotDispatched('404a1dbc-226a-46bd-9348-de2dd28f8d56');
         $this->assertScheduledEventNotDispatched('56738a7e-4bec-4c14-a8f7-7ef0ea58f204');
@@ -99,7 +77,6 @@ class DispatchScheduleReportsCommendDispatchTest extends LaravelTestCase
 
         $this->artisan('report:schedule');
 
-        $this->assertScheduledEventDispatch('d68a28d3-8544-4dd2-aeed-ed148eb37874');
         $this->assertScheduledEventDispatch('c066524b-b5ad-46d1-961d-f96203c54181');
         $this->assertScheduledEventDispatch('404a1dbc-226a-46bd-9348-de2dd28f8d56');
         $this->assertScheduledEventNotDispatched('56738a7e-4bec-4c14-a8f7-7ef0ea58f204');
@@ -114,7 +91,6 @@ class DispatchScheduleReportsCommendDispatchTest extends LaravelTestCase
 
         $this->artisan('report:schedule');
 
-        $this->assertScheduledEventDispatch('d68a28d3-8544-4dd2-aeed-ed148eb37874');
         $this->assertScheduledEventDispatch('c066524b-b5ad-46d1-961d-f96203c54181');
         $this->assertScheduledEventNotDispatched('404a1dbc-226a-46bd-9348-de2dd28f8d56');
         $this->assertScheduledEventDispatch('56738a7e-4bec-4c14-a8f7-7ef0ea58f204');
@@ -129,7 +105,6 @@ class DispatchScheduleReportsCommendDispatchTest extends LaravelTestCase
 
         $this->artisan('report:schedule');
 
-        $this->assertScheduledEventDispatch('d68a28d3-8544-4dd2-aeed-ed148eb37874');
         $this->assertScheduledEventDispatch('c066524b-b5ad-46d1-961d-f96203c54181');
         $this->assertScheduledEventNotDispatched('404a1dbc-226a-46bd-9348-de2dd28f8d56');
         $this->assertScheduledEventDispatch('56738a7e-4bec-4c14-a8f7-7ef0ea58f204');
@@ -144,7 +119,6 @@ class DispatchScheduleReportsCommendDispatchTest extends LaravelTestCase
 
         $this->artisan('report:schedule');
 
-        $this->assertScheduledEventDispatch('d68a28d3-8544-4dd2-aeed-ed148eb37874');
         $this->assertScheduledEventDispatch('c066524b-b5ad-46d1-961d-f96203c54181');
         $this->assertScheduledEventNotDispatched('404a1dbc-226a-46bd-9348-de2dd28f8d56');
         $this->assertScheduledEventDispatch('56738a7e-4bec-4c14-a8f7-7ef0ea58f204');

--- a/tests/Unit/Repositories/ScheduledReportRepositoryTest.php
+++ b/tests/Unit/Repositories/ScheduledReportRepositoryTest.php
@@ -32,12 +32,6 @@ class ScheduledReportRepositoryTest extends LaravelTestCase
         $this->report = factory(Report::class)->create();
 
         factory(ScheduledReport::class)->create([
-            'uuid' => 'd68a28d3-8544-4dd2-aeed-ed148eb37874',
-            'frequency' => ReportSchedule::HOURLY,
-            'report_id' => $this->report->getKey()
-        ]);
-
-        factory(ScheduledReport::class)->create([
             'uuid' => 'c066524b-b5ad-46d1-961d-f96203c54181',
             'frequency' => ReportSchedule::DAILY,
             'report_id' => $this->report->getKey()
@@ -69,23 +63,12 @@ class ScheduledReportRepositoryTest extends LaravelTestCase
     }
 
     /** @test **/
-    public function can_run_hourly_schedule(): void
-    {
-        $date = Carbon::parse('2021-11-10 09:00:00'); // on the hour (Wednesday)
-
-        $this->assertEquals([
-            'd68a28d3-8544-4dd2-aeed-ed148eb37874', // HOURLY
-        ], $this->repository->getScheduledReportsToRun($date)->pluck('uuid')->toArray());
-    }
-
-    /** @test **/
     public function can_run_daily_schedule(): void
     {
         $date = Carbon::parse('2021-11-10 00:00:00'); // daily at midnight (Wednesday)
 
         $this->assertEquals([
             'c066524b-b5ad-46d1-961d-f96203c54181', // DAILY
-            'd68a28d3-8544-4dd2-aeed-ed148eb37874', // HOURLY
         ], $this->repository->getScheduledReportsToRun($date)->pluck('uuid')->toArray());
     }
 
@@ -96,7 +79,6 @@ class ScheduledReportRepositoryTest extends LaravelTestCase
 
         $this->assertEquals([
             'c066524b-b5ad-46d1-961d-f96203c54181', // DAILY
-            'd68a28d3-8544-4dd2-aeed-ed148eb37874', // HOURLY
             '404a1dbc-226a-46bd-9348-de2dd28f8d56', // WEEKLY
         ], $this->repository->getScheduledReportsToRun($date)->pluck('uuid')->toArray());
     }
@@ -108,7 +90,6 @@ class ScheduledReportRepositoryTest extends LaravelTestCase
 
         $this->assertEquals([
             'c066524b-b5ad-46d1-961d-f96203c54181', // DAILY
-            'd68a28d3-8544-4dd2-aeed-ed148eb37874', // HOURLY
             '56738a7e-4bec-4c14-a8f7-7ef0ea58f204', // MONTHLY
         ], $this->repository->getScheduledReportsToRun($date)->pluck('uuid')->toArray());
     }
@@ -120,7 +101,6 @@ class ScheduledReportRepositoryTest extends LaravelTestCase
 
         $this->assertEquals([
             'c066524b-b5ad-46d1-961d-f96203c54181', // DAILY
-            'd68a28d3-8544-4dd2-aeed-ed148eb37874', // HOURLY
             '56738a7e-4bec-4c14-a8f7-7ef0ea58f204', // MONTHLY
             '417aa61e-3219-422d-9111-f701daf7e18f', // QUARTERLY
         ], $this->repository->getScheduledReportsToRun($date)->pluck('uuid')->toArray());
@@ -133,7 +113,6 @@ class ScheduledReportRepositoryTest extends LaravelTestCase
 
         $this->assertEquals([
             'c066524b-b5ad-46d1-961d-f96203c54181', // DAILY
-            'd68a28d3-8544-4dd2-aeed-ed148eb37874', // HOURLY
             '56738a7e-4bec-4c14-a8f7-7ef0ea58f204', // MONTHLY
             '417aa61e-3219-422d-9111-f701daf7e18f', // QUARTERLY
             '2930826c-6732-44e6-9c19-f62153ad53a9', // YEARLY
@@ -146,7 +125,7 @@ class ScheduledReportRepositoryTest extends LaravelTestCase
         $date = Carbon::parse('2021-11-10 09:00:40');
 
         $this->assertEquals([
-            'd68a28d3-8544-4dd2-aeed-ed148eb37874', // HOURLY
+            
         ], $this->repository->getScheduledReportsToRun($date)->pluck('uuid')->toArray());
     }
 
@@ -157,7 +136,6 @@ class ScheduledReportRepositoryTest extends LaravelTestCase
 
         $this->assertEquals([
             'c066524b-b5ad-46d1-961d-f96203c54181', // DAILY
-            'd68a28d3-8544-4dd2-aeed-ed148eb37874', // HOURLY
             '56738a7e-4bec-4c14-a8f7-7ef0ea58f204', // MONTHLY
             '417aa61e-3219-422d-9111-f701daf7e18f', // QUARTERLY
             '404a1dbc-226a-46bd-9348-de2dd28f8d56', // WEEKLY

--- a/tests/database/factories/ModelFactory.php
+++ b/tests/database/factories/ModelFactory.php
@@ -9,6 +9,7 @@ use MBLSolutions\Report\DataType\CastTitleCaseString;
 use MBLSolutions\Report\Driver\QueuedExport\CsvQueuedExport;
 use MBLSolutions\Report\Models\Report;
 use MBLSolutions\Report\Models\ReportField;
+use MBLSolutions\Report\Models\ReportFieldType;
 use MBLSolutions\Report\Models\ReportJob;
 use MBLSolutions\Report\Models\ReportJoin;
 use MBLSolutions\Report\Models\ReportMiddleware;
@@ -75,9 +76,51 @@ $factory->define(ReportField::class, static function (Faker $faker) {
             return factory(Report::class)->create();
         },
         'label' => 'Created At',
-        'type' => 'datetime',
+        'type' => ReportFieldType::DATETIME,
         'model' => null,
         'alias' => 'users_created_date',
+        'model_select_value' => null,
+        'model_select_name' => null
+    ];
+});
+
+$factory->state(ReportField::class, 'time', static function (Faker $faker) {
+    return [
+        'report_id' => function () {
+            return factory(Report::class)->create();
+        },
+        'label' => 'Start Time',
+        'type' => ReportFieldType::TIME,
+        'model' => null,
+        'alias' => 'start_time',
+        'model_select_value' => null,
+        'model_select_name' => null
+    ];
+});
+
+$factory->state(ReportField::class, 'date', static function (Faker $faker) {
+    return [
+        'report_id' => function () {
+            return factory(Report::class)->create();
+        },
+        'label' => 'Start Date',
+        'type' => ReportFieldType::DATE,
+        'model' => null,
+        'alias' => 'start_date',
+        'model_select_value' => null,
+        'model_select_name' => null
+    ];
+});
+
+$factory->state(ReportField::class, 'datetime', static function (Faker $faker) {
+    return [
+        'report_id' => function () {
+            return factory(Report::class)->create();
+        },
+        'label' => 'Start DateTime',
+        'type' => ReportFieldType::DATETIME,
+        'model' => null,
+        'alias' => 'start_date',
         'model_select_value' => null,
         'model_select_name' => null
     ];


### PR DESCRIPTION
## v2.6.0

+ Remove hourly from report schedule due to complexities on time based replacements (to be added back in once time permits)
+ Apply date filtering to scheduled reports 
  + e.g. Today 2021-01-01 00:00:00 (daily report would replace parameters start_date 2020-12-31 00:00:00 end_date 2020-12-31 23:59:59)
