### PR TITLE
add parameters to spredsheets, fix schedule id on report jobs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+## v2.6.4
+
++ Add parameters to supported export types (xls, xlsx and ods)
++ Fixed an issue where schedule ids were being incorrectly saved to report_jobs
+
 ## v2.6.3
 
 + Inject authenticatable into Report Render Job

--- a/src/Driver/QueuedExport/OdsQueuedExport.php
+++ b/src/Driver/QueuedExport/OdsQueuedExport.php
@@ -3,7 +3,7 @@
 namespace MBLSolutions\Report\Driver\QueuedExport;
 
 use Maatwebsite\Excel\Facades\Excel;
-use MBLSolutions\Report\Export\Report\ReportExport;
+use MBLSolutions\Report\Export\Report\SheetedReportExport;
 
 class OdsQueuedExport extends QueuedReportExport
 {
@@ -11,7 +11,7 @@ class OdsQueuedExport extends QueuedReportExport
 
     public function storeExportAs(string $path, string $filesystem): bool
     {
-        $export = new ReportExport($this->service, $this->offset, $this->limit);
+        $export = new SheetedReportExport($this->service, $this->offset, $this->limit);
 
         return Excel::store($export, $path . '.ods', $filesystem, \Maatwebsite\Excel\Excel::ODS);
     }

--- a/src/Driver/QueuedExport/XlsQueuedExport.php
+++ b/src/Driver/QueuedExport/XlsQueuedExport.php
@@ -3,7 +3,7 @@
 namespace MBLSolutions\Report\Driver\QueuedExport;
 
 use Maatwebsite\Excel\Facades\Excel;
-use MBLSolutions\Report\Export\Report\ReportExport;
+use MBLSolutions\Report\Export\Report\SheetedReportExport;
 
 class XlsQueuedExport extends QueuedReportExport
 {
@@ -11,7 +11,7 @@ class XlsQueuedExport extends QueuedReportExport
 
     public function storeExportAs(string $path, string $filesystem): bool
     {
-        $export = new ReportExport($this->service, $this->offset, $this->limit);
+        $export = new SheetedReportExport($this->service, $this->offset, $this->limit);
 
         return Excel::store($export, $path . '.xls', $filesystem, \Maatwebsite\Excel\Excel::XLS);
     }

--- a/src/Driver/QueuedExport/XlsxQueuedExport.php
+++ b/src/Driver/QueuedExport/XlsxQueuedExport.php
@@ -3,7 +3,7 @@
 namespace MBLSolutions\Report\Driver\QueuedExport;
 
 use Maatwebsite\Excel\Facades\Excel;
-use MBLSolutions\Report\Export\Report\ReportExport;
+use MBLSolutions\Report\Export\Report\SheetedReportExport;
 
 class XlsxQueuedExport extends QueuedReportExport
 {
@@ -11,7 +11,7 @@ class XlsxQueuedExport extends QueuedReportExport
 
     public function storeExportAs(string $path, string $filesystem): bool
     {
-        $export = new ReportExport($this->service, $this->offset, $this->limit);
+        $export = new SheetedReportExport($this->service, $this->offset, $this->limit);
 
         return Excel::store($export, $path . '.xlsx', $filesystem, \Maatwebsite\Excel\Excel::XLSX);
     }

--- a/src/Export/Report/ExportableReport.php
+++ b/src/Export/Report/ExportableReport.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace MBLSolutions\Report\Export\Report;
+
+use MBLSolutions\Report\Services\BuildReportService;
+
+abstract class ExportableReport
+{
+    protected BuildReportService $service;
+
+    protected int $offset;
+
+    protected int $limit;
+
+    /**
+     * @param BuildReportService $service
+     * @param int $offset
+     * @param int $limit
+     */
+    public function __construct(BuildReportService $service, int $offset, int $limit)
+    {
+        $this->service = $service;
+        $this->offset = $offset;
+        $this->limit = $limit;
+    }
+
+}

--- a/src/Export/Report/SheetedReportExport.php
+++ b/src/Export/Report/SheetedReportExport.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace MBLSolutions\Report\Export\Report;
+
+use Maatwebsite\Excel\Concerns\Exportable;
+use Maatwebsite\Excel\Concerns\WithMultipleSheets;
+use MBLSolutions\Report\Export\Sheets\ReportDataSheet;
+use MBLSolutions\Report\Export\Sheets\ReportParametersSheet;
+
+class SheetedReportExport extends ExportableReport implements WithMultipleSheets
+{
+    use Exportable;
+
+    public function sheets(): array
+    {
+        return [
+            new ReportDataSheet($this->service, $this->offset, $this->limit),
+            new ReportParametersSheet($this->service, $this->offset, $this->limit)
+        ];
+    }
+
+}

--- a/src/Export/Sheets/ReportDataSheet.php
+++ b/src/Export/Sheets/ReportDataSheet.php
@@ -1,12 +1,14 @@
 <?php
 
-namespace MBLSolutions\Report\Export\Report;
+namespace MBLSolutions\Report\Export\Sheets;
 
 use Illuminate\Support\Collection;
 use Maatwebsite\Excel\Concerns\FromCollection;
 use Maatwebsite\Excel\Concerns\WithHeadings;
+use Maatwebsite\Excel\Concerns\WithTitle;
+use MBLSolutions\Report\Export\Report\ExportableReport;
 
-class ReportExport extends ExportableReport implements FromCollection, WithHeadings
+class ReportDataSheet extends ExportableReport implements FromCollection, WithHeadings, WithTitle
 {
 
     public function headings(): array
@@ -19,4 +21,8 @@ class ReportExport extends ExportableReport implements FromCollection, WithHeadi
         return $this->service->getRenderedChunk($this->offset, $this->limit);
     }
 
+    public function title(): string
+    {
+        return $this->service->report->getAttribute('name');
+    }
 }

--- a/src/Export/Sheets/ReportParametersSheet.php
+++ b/src/Export/Sheets/ReportParametersSheet.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace MBLSolutions\Report\Export\Sheets;
+
+use Maatwebsite\Excel\Concerns\FromCollection;
+use Maatwebsite\Excel\Concerns\WithHeadings;
+use Maatwebsite\Excel\Concerns\WithTitle;
+use MBLSolutions\Report\Export\Report\ExportableReport;
+
+class ReportParametersSheet extends ExportableReport implements FromCollection, WithHeadings, WithTitle
+{
+
+    public function collection()
+    {
+        return $this->service->getFormattedParameters($this->service->parameters);
+    }
+
+    public function headings(): array
+    {
+        return [
+            'Parameters',
+            'Value'
+        ];
+    }
+
+    public function title(): string
+    {
+        return 'Parameters';
+    }
+}

--- a/src/Jobs/RenderReport.php
+++ b/src/Jobs/RenderReport.php
@@ -56,7 +56,7 @@ class RenderReport extends RenderReportJob
                 'total' => $this->getBuildReportService()->getTotalResults(),
                 'parameters' => $this->request,
                 'formatted_parameters' => (new BuildReportService($this->report, $this->request, true, $this->authenticatable))->getFormattedParameters($this->request),
-                'schedule_id' => $this->schedule,
+                'schedule_id' => optional($this->schedule)->getKey(),
             ];
 
             if ($this->authenticatable) {

--- a/src/Services/BuildReportService.php
+++ b/src/Services/BuildReportService.php
@@ -26,9 +26,9 @@ class BuildReportService
 {
     public bool $paginate = true;
 
-    protected Report $report;
+    public Report $report;
 
-    protected Collection $parameters;
+    public Collection $parameters;
 
     protected ?Collection $headings = null;
 


### PR DESCRIPTION
## v2.6.4

+ Add parameters to supported export types (xls, xlsx and ods)
+ Fixed an issue where schedule ids were being incorrectly saved to report_jobs