### PR TITLE
v3.0.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+## v3.0.0
+
++ PHP supported versions are now ^8.0|^8.1
++ Remove support for Laravel ^v5.x|^v6.x|^v7.x
+
 ## v2.7.7
 
 + AWS temp URLs are only available upto 7 days

--- a/composer.json
+++ b/composer.json
@@ -11,22 +11,23 @@
     }
   ],
   "require": {
-    "php": "^7.4|^8.0",
+    "php": "^8.0|^8.1",
     "ext-json": "*",
-    "illuminate/cache": "^6.0|^7.0|^8.0",
-    "illuminate/console": "^6.0|^7.0|^8.0",
-    "illuminate/database": "^6.0|^7.30.5|^8.0",
-    "illuminate/events": "^6.0|^7.0|^8.0",
-    "illuminate/filesystem": "^6.0|^7.0|^8.0",
-    "illuminate/queue": "^6.0|^7.0|^8.0",
-    "illuminate/support": "^6.0|^7.0|^8.0",
-    "illuminate/http": "^6.0|^7.0|^8.0",
+    "illuminate/cache": "^8.0",
+    "illuminate/console": "^8.0",
+    "illuminate/database": "^7.30.5|^8.0",
+    "illuminate/events": "^8.0",
+    "illuminate/filesystem": "^8.0",
+    "illuminate/queue": "^8.0",
+    "illuminate/support": "^8.0",
+    "illuminate/http": "^8.0",
     "maatwebsite/excel": "^3.1",
-    "lerouse/laravel-repository": "^1.2"
+    "lerouse/laravel-repository": "^2.0",
+    "laravel/legacy-factories": "^1.2"
   },
   "require-dev": {
     "mockery/mockery": "~1.0",
-    "orchestra/testbench": "^4.0",
+    "orchestra/testbench": "^6.0",
     "phpunit/phpunit": "^9.0"
   },
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "ext-json": "*",
     "illuminate/cache": "^8.0",
     "illuminate/console": "^8.0",
-    "illuminate/database": "^7.30.5|^8.0",
+    "illuminate/database": "^8.0",
     "illuminate/events": "^8.0",
     "illuminate/filesystem": "^8.0",
     "illuminate/queue": "^8.0",


### PR DESCRIPTION
## v3.0.0

+ PHP supported versions are now ^8.0|^8.1
+ Remove support for Laravel ^v5.x|^v6.x|^v7.x