### PR TITLE
AB#49551 Fixed replaceParameter to remove null values from query

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+## v5.2.3
+
++ Fix bug for replaceParameter to correctly remove NULL values from query
+
 ## v5.2.2
 
 + Fix bug that trimmed the leading and,or,in from a WHERE clause, which required `1=1 AND` temp fix.

--- a/src/Services/BuildReportService.php
+++ b/src/Services/BuildReportService.php
@@ -378,7 +378,26 @@ class BuildReportService
     public function replaceParameter(string $field, $value, $subject)
     {
         if ($value == null) {
-            return preg_replace("/((AND\s*)?([a-z._]+)(\s?)(>=|<=|=|<|>|!=|<>)(\s?)(\\'?)(\{{$field}\})(\s?)([0-9:]*)(\\'?)?)/", '', $subject);
+            preg_match_all("/([a-z._]+)(\s?)(>=|<=|=|<|>|!=|<>)(\s?)(\\'?)(\{{$field}\})(\s?)([0-9:]*)(\\'?)/", $subject, $matches);
+
+            foreach ($matches[0] as $match) {
+                $match = trim($match);
+
+                // Check for a leading "AND" or "OR"
+                if (preg_match("/\s*(AND|OR)\s+" . preg_quote($match, '/') . "/i", $subject)) {
+                    $subject = preg_replace("/\s*(AND|OR)\s+" . preg_quote($match, '/') . "/i", '', $subject);
+                }
+                // Check for a trailing "AND" or "OR"
+                else if (preg_match("/" . preg_quote($match, '/') . "\s+(AND|OR)\s*/i", $subject)) {
+                    $subject = preg_replace("/" . preg_quote($match, '/') . "\s+(AND|OR)\s*/i", '', $subject);
+                }
+                // If neither, simply remove the match (no AND/OR condition)
+                else {
+                    $subject = str_replace($match, '', $subject);
+                }
+            }
+
+            return $subject;
         }
 
         return preg_replace("/(\{{$field}\}|\{\{{$field}\}\})/i", $value, $subject);

--- a/tests/Unit/Services/BuildReportServiceTest.php
+++ b/tests/Unit/Services/BuildReportServiceTest.php
@@ -437,6 +437,63 @@ class BuildReportServiceTest extends LaravelTestCase
     }
 
     /** @test **/
+    public function can_replace_parameter_if_supplied_null_leading_and_or(): void
+    {
+        $service = new BuildReportService($this->report, []);
+
+        $method = new \ReflectionMethod(BuildReportService::class, 'replaceParameter');
+        $method->setAccessible(true);
+
+        $this->assertEquals(
+            'users.created_at > \'{users_created_at}\'',
+            $method->invoke(
+                $service,
+                'client_name',
+                null,
+                'users.created_at > \'{users_created_at}\' OR users.client_name > \'{client_name}\''
+            )
+        );
+    }
+
+    /** @test **/
+    public function can_replace_parameter_if_supplied_null_trailing_and_or(): void
+    {
+        $service = new BuildReportService($this->report, []);
+
+        $method = new \ReflectionMethod(BuildReportService::class, 'replaceParameter');
+        $method->setAccessible(true);
+
+        $this->assertEquals(
+            'users.created_at > \'{users_created_at}\'',
+            $method->invoke(
+                $service,
+                'client_name',
+                null,
+                'users.client_name > \'{client_name}\' AND users.created_at > \'{users_created_at}\''
+            )
+        );
+    }
+
+    /** @test **/
+    public function can_replace_parameter_if_supplied_null_leading_and_trailing_and_or(): void
+    {
+        $service = new BuildReportService($this->report, []);
+
+        $method = new \ReflectionMethod(BuildReportService::class, 'replaceParameter');
+        $method->setAccessible(true);
+
+        $this->assertEquals(
+            'users.role > \'{users_role}\' AND users.created_at > \'{users_created_at}\'',
+            $method->invoke(
+                $service,
+                'client_name',
+                null,
+                'users.role > \'{users_role}\' OR users.client_name > \'{client_name}\' AND users.created_at > \'{users_created_at}\''
+            )
+        );
+    }
+
+    /** @test **/
     public function can_replace_parameter_if_supplied_null_with_extended_time_stamp(): void
     {
         $report = factory(Report::class)->create([


### PR DESCRIPTION
Correctly removes null value fields from query, as well as leading and trailing "AND" and "OR" (case insensitive).
It must not remove both leading and trailing AND|OR, only one, else the query could break.
In such scenario, the leading AND|OR takes preference. If leading one doesn't exist, only then the trailing AND|OR is removed.
If neither exist, then just the null value field is removed.